### PR TITLE
ci: publish job runs in dockerhub-publish environment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    environment: dockerhub-publish
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Pins the Docker publish job to the `dockerhub-publish` environment (deployment branch policy: protected branches only). Repo-level DOCKERHUB secrets keep working until they are re-entered as environment secrets, then the repo-level ones can be deleted so only main-branch runs can reach them.