### PR TITLE
ci: skip claude review on fork PRs, re-review on push

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,12 +2,17 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review, reopened]
+    types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
   claude-review:
-    # Skip Dependabot PRs
-    if: github.actor != 'dependabot[bot]'
+    # Skip Dependabot PRs, and skip fork PRs: fork-originated pull_request runs
+    # get no secrets and no id-token, so the action cannot authenticate.
+    # Fork PRs can still be reviewed on demand by commenting @claude (claude.yml
+    # runs on issue_comment in base-repo context, where secrets are available).
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Fork-originated `pull_request` runs get no secrets and no id-token, so claude-code-action cannot authenticate and the check goes red (see PR #44). Skip the job for fork PRs instead; fork PRs can still get an on-demand review via an `@claude` comment, which runs in base-repo context with secrets. Also adds `synchronize` so in-repo PRs get re-reviewed on push (sticky comment keeps it to one thread).