### PR TITLE
fix: derive __version__ from package metadata

### DIFF
--- a/src/polar_flow_server/__init__.py
+++ b/src/polar_flow_server/__init__.py
@@ -1,5 +1,10 @@
 """polar-flow-server - Self-hosted health analytics server for Polar devices."""
 
-__version__ = "1.3.3"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("polar-flow-server")
+except PackageNotFoundError:  # running from a source checkout without an install
+    __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -1425,7 +1425,7 @@ wheels = [
 
 [[package]]
 name = "polar-flow-server"
-version = "1.3.4"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },


### PR DESCRIPTION
Follow-up to #47, addressing the review: `__init__.py` was hardcoded at `1.3.3` (stale since January), so `/health`, the OpenAPI spec, and `--version` under-report — live prod says `1.3.3` right now, and the `1.4.0` Docker image published from the #47 merge reports `1.3.3` too.

Fix: resolve `__version__` via `importlib.metadata` with a safe fallback for uninstalled source checkouts, making `pyproject.toml` the single source of truth. Also bumps the project version stamp in `uv.lock` (version-only change, no dependency updates).

Verified locally: `__version__` resolves `1.4.0`, 77/77 tests pass. Tag `v1.4.0` after this merges so the release actually reports itself correctly.