### PR TITLE
fix: ANS load scale alignment  (-10 to +10)

### DIFF
--- a/src/polar_flow_server/admin/routes.py
+++ b/src/polar_flow_server/admin/routes.py
@@ -1565,7 +1565,9 @@ async def chart_hrv_data(
         "labels": [r.date.isoformat() for r in recharge_data],
         "datasets": {
             "hrv_avg": [r.hrv_avg or 0 for r in recharge_data],
-            "ans_charge": [r.ans_charge if r.ans_charge is not None else None for r in recharge_data],
+            "ans_charge": [
+                r.ans_charge if r.ans_charge is not None else None for r in recharge_data
+            ],
         },
     }
 

--- a/src/polar_flow_server/admin/routes.py
+++ b/src/polar_flow_server/admin/routes.py
@@ -263,11 +263,11 @@ def _calculate_recovery_status(
             recommendations.append("Poor sleep. Prioritize recovery over training.")
         factors.append(sleep_score)
 
-    # HRV/ANS factor (0-100)
+    # HRV/ANS factor (0-100), normalized from Polar's ANS charge scale (-10 to +10)
     ans_score: float = 50.0  # default
     if recharge:
-        if recharge.ans_charge:
-            ans_score = float(recharge.ans_charge)
+        if recharge.ans_charge is not None:
+            ans_score = min(100.0, max(0.0, (float(recharge.ans_charge) + 10.0) * 5.0))
             if ans_score >= 70:
                 recommendations.append("ANS recovery is excellent. Your body is ready for stress.")
             elif ans_score >= 50:

--- a/src/polar_flow_server/admin/routes.py
+++ b/src/polar_flow_server/admin/routes.py
@@ -1565,7 +1565,7 @@ async def chart_hrv_data(
         "labels": [r.date.isoformat() for r in recharge_data],
         "datasets": {
             "hrv_avg": [r.hrv_avg or 0 for r in recharge_data],
-            "ans_charge": [r.ans_charge or 0 for r in recharge_data],
+            "ans_charge": [r.ans_charge if r.ans_charge is not None else None for r in recharge_data],
         },
     }
 

--- a/src/polar_flow_server/models/recharge.py
+++ b/src/polar_flow_server/models/recharge.py
@@ -32,7 +32,7 @@ class NightlyRecharge(Base, UserScopedMixin, TimestampMixin):
     # Recharge date
     date: Mapped[date] = mapped_column(Date, nullable=False, index=True)
 
-    # ANS charge (0-100)
+    # ANS charge (-10 to +10)
     ans_charge: Mapped[float | None] = mapped_column(Float)
     ans_charge_status: Mapped[int | None] = mapped_column(
         Integer,

--- a/src/polar_flow_server/templates/admin/dashboard.html
+++ b/src/polar_flow_server/templates/admin/dashboard.html
@@ -928,7 +928,7 @@ const chartDescriptions = {
     hrv: {
         title: 'Recovery Metrics',
         hrv_avg: 'Heart Rate Variability in ms. Higher = better recovery. Track your baseline.',
-        ans_charge: 'ANS Charge (%). How well your autonomic nervous system recovered overnight.'
+        ans_charge: 'ANS Charge (-10 to +10). Higher values indicate better overnight ANS recovery.'
     },
     cardio: {
         title: 'Training Load',
@@ -1332,7 +1332,7 @@ function renderHrvChart(hrvData) {
                     yAxisID: 'y'
                 },
                 {
-                    label: 'ANS Charge (%)',
+                    label: 'ANS Charge',
                     data: hrvData.datasets.ans_charge,
                     borderColor: '#06b6d4',
                     borderDash: [5, 5],
@@ -1355,10 +1355,10 @@ function renderHrvChart(hrvData) {
                             if (label === 'HRV (ms)') {
                                 return '  Higher = better recovery. Track your personal baseline.';
                             }
-                            if (label === 'ANS Charge (%)') {
-                                if (v >= 70) return '  Excellent recovery';
-                                if (v >= 50) return '  Good recovery';
-                                if (v >= 30) return '  Moderate - take it easy';
+                            if (label === 'ANS Charge') {
+                                if (v >= 5) return '  Excellent recovery';
+                                if (v >= 1) return '  Good recovery';
+                                if (v >= -3) return '  Moderate - take it easy';
                                 return '  Poor - prioritize rest';
                             }
                             return '';
@@ -1369,7 +1369,7 @@ function renderHrvChart(hrvData) {
             scales: {
                 ...commonOptions.scales,
                 y: { ...commonOptions.scales.y, title: { display: true, text: 'HRV (ms)' } },
-                y1: { position: 'right', beginAtZero: true, max: 100, title: { display: true, text: 'ANS %' }, grid: { display: false } }
+                y1: { position: 'right', min: -10, max: 10, title: { display: true, text: 'ANS Charge' }, grid: { display: false } }
             }
         }
     });

--- a/src/polar_flow_server/templates/admin/dashboard.html
+++ b/src/polar_flow_server/templates/admin/dashboard.html
@@ -522,7 +522,7 @@
 
 <!-- Heart Charts -->
 <div class="mb-6 hidden" data-tab-panel="heart">
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
         <div class="bg-white shadow rounded-lg p-4">
             <h3 class="text-sm font-medium text-gray-700 mb-3">Heart Rate (Min/Avg/Max)</h3>
             <div class="h-64">
@@ -530,39 +530,57 @@
             </div>
         </div>
 
+        <div class="bg-white shadow rounded-lg p-6">
+            <h3 class="text-sm font-medium text-gray-700 mb-4">
+                Heart Rate Today{% if latest_hr %} ({{ latest_hr.date }}){% endif %}
+            </h3>
+            {% if latest_hr %}
+            <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
+                <div>
+                    <div class="text-gray-500 text-xs uppercase">Min</div>
+                    <div class="text-xl font-bold text-gray-900">{{ latest_hr.hr_min if latest_hr.hr_min else '--' }} <span class="text-sm font-normal text-gray-500">bpm</span></div>
+                </div>
+                <div>
+                    <div class="text-gray-500 text-xs uppercase">Avg</div>
+                    <div class="text-xl font-bold text-gray-900">{{ latest_hr.hr_avg if latest_hr.hr_avg else '--' }} <span class="text-sm font-normal text-gray-500">bpm</span></div>
+                </div>
+                <div>
+                    <div class="text-gray-500 text-xs uppercase">Max</div>
+                    <div class="text-xl font-bold text-gray-900">{{ latest_hr.hr_max if latest_hr.hr_max else '--' }} <span class="text-sm font-normal text-gray-500">bpm</span></div>
+                </div>
+                <div>
+                    <div class="text-gray-500 text-xs uppercase">Samples</div>
+                    <div class="text-xl font-bold text-gray-900">{{ latest_hr.sample_count }}</div>
+                </div>
+            </div>
+
+            {% if latest_hr.samples_json %}
+            <div class="mt-4 h-40">
+                <canvas id="todayHrHeartTabChart"></canvas>
+            </div>
+            {% else %}
+            <p class="mt-4 text-xs text-gray-500">No intraday heart-rate samples available for this date.</p>
+            {% endif %}
+            {% else %}
+            <div class="h-40 flex items-center justify-center text-sm text-gray-400">No heart rate summary yet</div>
+            {% endif %}
+        </div>
+
         <div class="bg-white shadow rounded-lg p-4">
-            <h3 class="text-sm font-medium text-gray-700 mb-3">HRV & Recovery</h3>
+            <h3 class="text-sm font-medium text-gray-700 mb-3">HRV (RMSSD)</h3>
             <div class="h-64">
                 <canvas id="hrvChart"></canvas>
             </div>
         </div>
-    </div>
-</div>
 
-<!-- Continuous HR Details -->
-{% if latest_hr %}
-<div class="bg-white shadow rounded-lg p-6 mb-6 hidden" data-tab-panel="heart">
-    <h2 class="text-lg font-semibold text-gray-900 mb-4">Heart Rate ({{ latest_hr.date }})</h2>
-    <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
-        <div>
-            <div class="text-gray-500 text-xs uppercase">Min</div>
-            <div class="text-xl font-bold text-gray-900">{{ latest_hr.hr_min if latest_hr.hr_min else '--' }} <span class="text-sm font-normal text-gray-500">bpm</span></div>
-        </div>
-        <div>
-            <div class="text-gray-500 text-xs uppercase">Avg</div>
-            <div class="text-xl font-bold text-gray-900">{{ latest_hr.hr_avg if latest_hr.hr_avg else '--' }} <span class="text-sm font-normal text-gray-500">bpm</span></div>
-        </div>
-        <div>
-            <div class="text-gray-500 text-xs uppercase">Max</div>
-            <div class="text-xl font-bold text-gray-900">{{ latest_hr.hr_max if latest_hr.hr_max else '--' }} <span class="text-sm font-normal text-gray-500">bpm</span></div>
-        </div>
-        <div>
-            <div class="text-gray-500 text-xs uppercase">Samples</div>
-            <div class="text-xl font-bold text-gray-900">{{ latest_hr.sample_count }}</div>
+        <div class="bg-white shadow rounded-lg p-4">
+            <h3 class="text-sm font-medium text-gray-700 mb-3">ANS Charge</h3>
+            <div class="h-64">
+                <canvas id="ansChart"></canvas>
+            </div>
         </div>
     </div>
 </div>
-{% endif %}
 
 <!-- Training Charts -->
 <div class="mb-6 hidden" data-tab-panel="training">
@@ -823,12 +841,12 @@
 // Chart instances, keyed by chart name. Charts are only ever created while their
 // tab panel is visible, so Chart.js measures the real canvas size and the default
 // entrance animation behaves consistently every time (no more reveal glitch).
-const charts = { sleepScore: null, sleepDuration: null, activity: null, hr: null, hrv: null, cardio: null };
+const charts = { sleepScore: null, sleepDuration: null, activity: null, hr: null, hrv: null, ans: null, todayHrHeart: null, cardio: null };
 
 // Which chart keys belong to each tab.
 const chartsByTab = {
     sleep: ['sleepScore', 'sleepDuration'],
-    heart: ['hr', 'hrv'],
+    heart: ['hr', 'hrv', 'ans', 'todayHrHeart'],
     training: ['activity', 'cardio']
 };
 
@@ -1016,6 +1034,8 @@ async function loadChartsForTab(tab) {
         ]);
         renderHrChart(hrData);
         renderHrvChart(hrvData);
+        renderAnsChart(hrvData);
+        renderTodayHrHeartTabChart();
     } else if (tab === 'training') {
         const [activityData, cardioData] = await Promise.all([
             fetch(`/admin/api/charts/activity?days=${days}`).then(r => r.json()),
@@ -1092,6 +1112,46 @@ const scoreLevelLinesPlugin = {
     }
 };
 Chart.register(scoreLevelLinesPlugin);
+
+// Dashed guide lines for ANS charge interpretation on the secondary y-axis.
+const ansReferenceLinesPlugin = {
+    id: 'ansReferenceLines',
+    afterDraw(chart, _args, options) {
+        if (!options || !options.levels || !options.levels.length) return;
+        const { ctx, chartArea, scales } = chart;
+        const yScale = scales[options.yScaleId || 'y1'];
+        if (!yScale) return;
+
+        ctx.save();
+        ctx.textBaseline = 'middle';
+        ctx.font = '11px sans-serif';
+        ctx.textAlign = 'right';
+
+        options.levels.forEach((level) => {
+            if (typeof level.value !== 'number') return;
+
+            const y = yScale.getPixelForValue(level.value);
+            if (y < chartArea.top || y > chartArea.bottom) return;
+
+            ctx.strokeStyle = level.color || '#9ca3af';
+            ctx.lineWidth = 1;
+            ctx.setLineDash(level.dash || [4, 4]);
+            ctx.beginPath();
+            ctx.moveTo(chartArea.left, y);
+            ctx.lineTo(chartArea.right, y);
+            ctx.stroke();
+            ctx.setLineDash([]);
+
+            if (level.label) {
+                ctx.fillStyle = level.color || '#6b7280';
+                ctx.fillText(level.label, chartArea.right - 6, y - 8);
+            }
+        });
+
+        ctx.restore();
+    }
+};
+Chart.register(ansReferenceLinesPlugin);
 
 function renderSleepScoreChart(sleepData) {
     if (charts.sleepScore) charts.sleepScore.destroy();
@@ -1328,16 +1388,7 @@ function renderHrvChart(hrvData) {
                     borderColor: '#8b5cf6',
                     backgroundColor: 'rgba(139, 92, 246, 0.1)',
                     fill: true,
-                    tension: 0.3,
-                    yAxisID: 'y'
-                },
-                {
-                    label: 'ANS Charge',
-                    data: hrvData.datasets.ans_charge,
-                    borderColor: '#06b6d4',
-                    borderDash: [5, 5],
-                    tension: 0.3,
-                    yAxisID: 'y1'
+                    tension: 0.3
                 }
             ]
         },
@@ -1348,28 +1399,68 @@ function renderHrvChart(hrvData) {
                 tooltip: {
                     ...commonOptions.plugins.tooltip,
                     callbacks: {
-                        afterTitle: () => 'Recovery Metrics',
+                        afterTitle: () => 'HRV Trend',
+                        afterLabel: () => '  Higher = better recovery. Track your personal baseline.'
+                    }
+                }
+            },
+            scales: {
+                ...commonOptions.scales,
+                y: { ...commonOptions.scales.y, title: { display: true, text: 'HRV (ms)' } }
+            }
+        }
+    });
+}
+
+// ANS Charge Chart
+function renderAnsChart(hrvData) {
+    if (charts.ans) charts.ans.destroy();
+    const hrvLabels = hrvData.labels.map(formatDateLabel);
+    charts.ans = new Chart(document.getElementById('ansChart'), {
+        type: 'line',
+        data: {
+            labels: hrvLabels,
+            datasets: [
+                {
+                    label: 'ANS Charge',
+                    data: hrvData.datasets.ans_charge,
+                    borderColor: '#06b6d4',
+                    borderDash: [5, 5],
+                    backgroundColor: 'rgba(6, 182, 212, 0.08)',
+                    fill: true,
+                    tension: 0.3
+                }
+            ]
+        },
+        options: {
+            ...commonOptions,
+            plugins: {
+                ...commonOptions.plugins,
+                ansReferenceLines: {
+                    yScaleId: 'y',
+                    levels: [
+                        { value: 5, label: '+5', color: '#22c55e', dash: [5, 5] },
+                        { value: 0, label: '0', color: '#6b7280', dash: [6, 3] },
+                        { value: -5, label: '-5', color: '#f59e0b', dash: [5, 5] }
+                    ]
+                },
+                tooltip: {
+                    ...commonOptions.plugins.tooltip,
+                    callbacks: {
+                        afterTitle: () => 'ANS Charge Trend',
                         afterLabel: (ctx) => {
-                            const label = ctx.dataset.label;
                             const v = ctx.raw;
-                            if (label === 'HRV (ms)') {
-                                return '  Higher = better recovery. Track your personal baseline.';
-                            }
-                            if (label === 'ANS Charge') {
-                                if (v >= 5) return '  Excellent recovery';
-                                if (v >= 1) return '  Good recovery';
-                                if (v >= -3) return '  Moderate - take it easy';
-                                return '  Poor - prioritize rest';
-                            }
-                            return '';
+                            if (v >= 5) return '  Excellent recovery';
+                            if (v >= 1) return '  Good recovery';
+                            if (v >= -3) return '  Moderate - take it easy';
+                            return '  Poor - prioritize rest';
                         }
                     }
                 }
             },
             scales: {
                 ...commonOptions.scales,
-                y: { ...commonOptions.scales.y, title: { display: true, text: 'HRV (ms)' } },
-                y1: { position: 'right', min: -10, max: 10, title: { display: true, text: 'ANS Charge' }, grid: { display: false } }
+                y: { ...commonOptions.scales.y, min: -10, max: 10, title: { display: true, text: 'ANS Charge' } }
             }
         }
     });
@@ -1692,6 +1783,64 @@ function renderTodayHrChart() {
             scales: {
                 x: { ticks: { maxTicksLimit: 8 }, grid: { display: false } },
                 y: { beginAtZero: false, grid: { color: '#f3f4f6' }, title: { display: true, text: 'BPM' } }
+            }
+        }
+    });
+}
+
+function renderTodayHrHeartTabChart() {
+    const canvas = document.getElementById('todayHrHeartTabChart');
+    const dataEl = document.getElementById('today-hr-samples');
+    if (!canvas || !dataEl) return;
+
+    let samples = [];
+    try {
+        samples = JSON.parse(dataEl.textContent || '[]');
+    } catch (e) {
+        samples = [];
+    }
+    if (!samples.length) return;
+
+    if (charts.todayHrHeart) charts.todayHrHeart.destroy();
+
+    const rolledUp = rollupByTimeBucket(
+        samples,
+        ROLLUP_BUCKET_MINUTES,
+        (s) => timeStringToMinutes(s.sample_time),
+        (s) => s.heart_rate,
+        average
+    );
+
+    charts.todayHrHeart = new Chart(canvas, {
+        type: 'line',
+        data: {
+            labels: rolledUp.map(p => p.label),
+            datasets: [{
+                label: 'Today HR',
+                data: rolledUp.map(p => Math.round(p.value)),
+                borderColor: '#ef4444',
+                backgroundColor: 'rgba(239, 68, 68, 0.08)',
+                fill: true,
+                tension: 0.25,
+                pointRadius: 0
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            animation: { duration: 450 },
+            interaction: { intersect: false, mode: 'index' },
+            plugins: {
+                legend: { display: false },
+                tooltip: {
+                    callbacks: {
+                        label: (ctx) => `${ctx.raw} bpm (avg over ${ROLLUP_BUCKET_MINUTES}m)`
+                    }
+                }
+            },
+            scales: {
+                x: { ticks: { maxTicksLimit: 8 }, grid: { display: false } },
+                y: { beginAtZero: false, title: { display: true, text: 'BPM' }, grid: { color: '#f3f4f6' } }
             }
         }
     });

--- a/src/polar_flow_server/templates/admin/dashboard.html
+++ b/src/polar_flow_server/templates/admin/dashboard.html
@@ -1439,9 +1439,9 @@ function renderAnsChart(hrvData) {
                 ansReferenceLines: {
                     yScaleId: 'y',
                     levels: [
-                        { value: 5, label: '+5', color: '#22c55e', dash: [5, 5] },
+                        { value: 4, label: '+4', color: '#22c55e', dash: [5, 5] },
                         { value: 0, label: '0', color: '#6b7280', dash: [6, 3] },
-                        { value: -5, label: '-5', color: '#f59e0b', dash: [5, 5] }
+                        { value: -4, label: '-4', color: '#f59e0b', dash: [5, 5] }
                     ]
                 },
                 tooltip: {
@@ -1450,9 +1450,9 @@ function renderAnsChart(hrvData) {
                         afterTitle: () => 'ANS Charge Trend',
                         afterLabel: (ctx) => {
                             const v = ctx.raw;
-                            if (v >= 5) return '  Excellent recovery';
-                            if (v >= 1) return '  Good recovery';
-                            if (v >= -3) return '  Moderate - take it easy';
+                            if (v >= 4) return '  Excellent recovery';
+                            if (v >= 0) return '  Good recovery';
+                            if (v >= -4) return '  Moderate - take it easy';
                             return '  Poor - prioritize rest';
                         }
                     }
@@ -1733,6 +1733,10 @@ function isoTimestampToMinutes(timestamp) {
     return (h * 60) + m;
 }
 
+function isValidHeartRateValue(value) {
+    return value !== null && value !== undefined && value > 0;
+}
+
 function renderTodayHrChart() {
     const canvas = document.getElementById('todayHrChart');
     const dataEl = document.getElementById('today-hr-samples');
@@ -1746,8 +1750,11 @@ function renderTodayHrChart() {
     }
     if (!samples.length) return;
 
+    const validSamples = samples.filter((s) => isValidHeartRateValue(s.heart_rate));
+    if (!validSamples.length) return;
+
     const rolledUp = rollupByTimeBucket(
-        samples,
+        validSamples,
         ROLLUP_BUCKET_MINUTES,
         (s) => timeStringToMinutes(s.sample_time),
         (s) => s.heart_rate,
@@ -1801,10 +1808,13 @@ function renderTodayHrHeartTabChart() {
     }
     if (!samples.length) return;
 
+    const validSamples = samples.filter((s) => isValidHeartRateValue(s.heart_rate));
+    if (!validSamples.length) return;
+
     if (charts.todayHrHeart) charts.todayHrHeart.destroy();
 
     const rolledUp = rollupByTimeBucket(
-        samples,
+        validSamples,
         ROLLUP_BUCKET_MINUTES,
         (s) => timeStringToMinutes(s.sample_time),
         (s) => s.heart_rate,

--- a/src/polar_flow_server/templates/admin/dashboard.html
+++ b/src/polar_flow_server/templates/admin/dashboard.html
@@ -497,7 +497,7 @@
                             {% if recharge.hrv_avg %}{{ recharge.hrv_avg|round(0) }} ms{% else %}--{% endif %}
                         </td>
                         <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-900">
-                            {% if recharge.ans_charge %}{{ recharge.ans_charge|round(0) }}%{% else %}--{% endif %}
+                            {% if recharge.ans_charge is not none %}{{ recharge.ans_charge|round(1) }}{% else %}--{% endif %}
                         </td>
                         <td class="px-4 py-2 whitespace-nowrap text-sm">
                             {% if recharge.nightly_recharge_status %}

--- a/src/polar_flow_server/transformers/continuous_hr.py
+++ b/src/polar_flow_server/transformers/continuous_hr.py
@@ -55,7 +55,9 @@ class ContinuousHRTransformer:
 
         if samples:
             # Ignore non-physiological placeholders when computing aggregates.
-            hr_values = [s.heart_rate for s in samples if s.heart_rate is not None and s.heart_rate > 0]
+            hr_values = [
+                s.heart_rate for s in samples if s.heart_rate is not None and s.heart_rate > 0
+            ]
         else:
             hr_values = []
 

--- a/src/polar_flow_server/transformers/continuous_hr.py
+++ b/src/polar_flow_server/transformers/continuous_hr.py
@@ -54,7 +54,12 @@ class ContinuousHRTransformer:
         hr_avg = None
 
         if samples:
-            hr_values = [s.heart_rate for s in samples]
+            # Ignore non-physiological placeholders when computing aggregates.
+            hr_values = [s.heart_rate for s in samples if s.heart_rate is not None and s.heart_rate > 0]
+        else:
+            hr_values = []
+
+        if hr_values:
             hr_min = min(hr_values)
             hr_max = max(hr_values)
             hr_avg = round(sum(hr_values) / len(hr_values))

--- a/tests/fixtures/analytics_seed.py
+++ b/tests/fixtures/analytics_seed.py
@@ -196,7 +196,7 @@ async def seed_analytics_data(
         recharge = NightlyRecharge(
             user_id=user_id,
             date=current_date,
-            ans_charge=random.uniform(40, 80),
+            ans_charge=random.uniform(-10, 10),
             ans_charge_status=random.randint(-1, 2),
             hrv_avg=hrv,
             hrv_status=0 if 25 <= hrv <= 45 else (-1 if hrv < 25 else 1),

--- a/tests/test_ans_scale_alignment.py
+++ b/tests/test_ans_scale_alignment.py
@@ -1,0 +1,95 @@
+"""Regression tests for ANS scale alignment and related HR handling."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import date, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import polar_flow_server.admin.routes as admin_routes
+from polar_flow_server.models.recharge import NightlyRecharge
+from polar_flow_server.transformers.continuous_hr import ContinuousHRTransformer
+
+
+@dataclass
+class _FakeHrSample:
+    heart_rate: int | None
+    sample_time: str
+
+
+@dataclass
+class _FakeContinuousHr:
+    date: str
+    heart_rate_samples: list[_FakeHrSample]
+
+
+@pytest.mark.parametrize(
+    ("ans_charge", "expected_score"),
+    [
+        (-10.0, 0),
+        (0.0, 50),
+        (10.0, 100),
+        (-20.0, 0),  # clamped
+        (20.0, 100),  # clamped
+    ],
+)
+def test_recovery_status_normalizes_and_clamps_ans(ans_charge: float, expected_score: int) -> None:
+    """ANS charge should be normalized from -10..10 to 0..100 and clamped."""
+    recharge = NightlyRecharge(user_id="user-1", date=date.today(), ans_charge=ans_charge)
+
+    status = admin_routes._calculate_recovery_status(sleep=None, recharge=recharge, cardio=None)
+
+    assert status["readiness_score"] == expected_score
+
+
+@pytest.mark.asyncio
+async def test_chart_hrv_data_preserves_missing_ans_as_null(
+    async_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing ANS charge should remain null in chart payload, not coerced to 0."""
+    monkeypatch.setattr(admin_routes, "is_authenticated", lambda _request: True)
+
+    today = date.today()
+    async_session.add_all(
+        [
+            NightlyRecharge(user_id="user-1", date=today - timedelta(days=1), hrv_avg=42.0),
+            NightlyRecharge(user_id="user-1", date=today, hrv_avg=45.0, ans_charge=2.0),
+        ]
+    )
+    await async_session.commit()
+
+    result = await admin_routes.chart_hrv_data(  # type: ignore[arg-type]
+        request=None,
+        session=async_session,
+        days=30,
+    )
+
+    assert result["datasets"]["ans_charge"] == [None, 2.0]
+
+
+def test_continuous_hr_transformer_filters_invalid_values_for_aggregates_only() -> None:
+    """Zero/None placeholders should not affect min/avg/max but raw samples are kept."""
+    sdk_hr = _FakeContinuousHr(
+        date=date.today().isoformat(),
+        heart_rate_samples=[
+            _FakeHrSample(heart_rate=None, sample_time="00:00"),
+            _FakeHrSample(heart_rate=0, sample_time="00:05"),
+            _FakeHrSample(heart_rate=55, sample_time="00:10"),
+            _FakeHrSample(heart_rate=65, sample_time="00:15"),
+        ],
+    )
+
+    result = ContinuousHRTransformer.transform(sdk_hr, "user-1")  # type: ignore[arg-type]
+
+    assert result["sample_count"] == 4
+    assert result["hr_min"] == 55
+    assert result["hr_avg"] == 60
+    assert result["hr_max"] == 65
+
+    raw_samples = json.loads(result["samples_json"])
+    assert len(raw_samples) == 4
+    assert raw_samples[0]["heart_rate"] is None
+    assert raw_samples[1]["heart_rate"] == 0

--- a/tests/test_ans_scale_alignment.py
+++ b/tests/test_ans_scale_alignment.py
@@ -61,7 +61,7 @@ async def test_chart_hrv_data_preserves_missing_ans_as_null(
     )
     await async_session.commit()
 
-    result = await admin_routes.chart_hrv_data(  # type: ignore[arg-type]
+    result = await admin_routes.chart_hrv_data.fn(  # type: ignore[arg-type]
         request=None,
         session=async_session,
         days=30,


### PR DESCRIPTION
## Summary

The app currently treats ANS charge as a percentage, but for Polar devices (at least Polar Loop) the raw ANS charge scale is -10 to +10.
This PR aligns the app with that scale and updates all affected surfaces:

- readiness scoring logic
- model/comments and labels
- dashboard tables
- charts (axis/range/thresholds)
- tooltip messaging

It also fixes empty points in HR data for minimum computation !

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes (describe below)

## Test plan

- [ ] Tests added/updated
- [x] Manually tested locally

## Checklist

- [ ] Code follows project conventions
- [ ] Documentation updated if needed
