### PR TITLE
ci: only auto-review on PR open, not every push

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,8 +1,12 @@
 name: Claude Code Review
 
 on:
+  # Auto-review once when a PR opens (or reopens / leaves draft). Deliberately
+  # NOT on `synchronize` — re-reviewing every push is noise. To re-review after
+  # changes, comment `@claude` (handled by claude.yml, which runs with secrets
+  # in base-repo context and so works for fork PRs too).
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, ready_for_review, reopened]
 
 jobs:
   claude-review:


### PR DESCRIPTION
The `synchronize` trigger (added in #46) re-runs the Claude review on every push to a PR — too noisy. Drop it: auto-review fires once on open/reopen/ready-for-review, and `@claude` comments still trigger an on-demand re-review (via claude.yml, which works on fork PRs too since it runs in base-repo context with secrets).