### PR TITLE
fix: persist encryption & session keys across redeploys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,17 @@ DATABASE_URL=postgresql+asyncpg://polar:polar@postgres:5432/polar
 # DATABASE_URL=postgresql+asyncpg://user:pass@host:5432/dbname
 
 # Security (required for SaaS mode, generates default for self-hosted)
+# Generate an encryption key with:
+#   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 # ENCRYPTION_KEY=<base64-encoded-32-byte-key>
+# SESSION_SECRET=<random-string>
 # JWT_SECRET=<secret-key>
+
+# Where auto-generated keys are persisted when ENCRYPTION_KEY/SESSION_SECRET are
+# not set. Defaults to ~/.polar-flow (bare metal) or /data/keys (Docker image).
+# In Docker this directory MUST be on a persistent volume — losing the
+# encryption key makes all stored Polar tokens permanently undecryptable.
+# KEY_DIR=/data/keys
 
 # Sync settings
 SYNC_ENABLED=true                    # Enable/disable automatic background syncing

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,11 @@ COPY alembic/ alembic/
 # Install dependencies
 RUN uv sync --frozen --no-dev
 
-# Create data directory
-RUN mkdir -p /data
+# Persistent data directory. KEY_DIR moves the auto-generated encryption/session
+# keys off the (ephemeral) container home dir — mount a volume over /data or the
+# keys are regenerated on every recreate and stored Polar tokens become unreadable.
+RUN mkdir -p /data/keys
+ENV KEY_DIR=/data/keys
 
 # Copy and set up entrypoint
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -25,6 +25,11 @@ services:
         condition: service_healthy
     environment:
       DATABASE_URL: postgresql+asyncpg://polar:polar@postgres:5432/polar
+    volumes:
+      # Persists auto-generated encryption/session keys (KEY_DIR=/data/keys).
+      # Without this, every recreate regenerates the encryption key and all
+      # stored Polar tokens become permanently undecryptable.
+      - app-data:/data
     ports:
       - "8000:8000"
     healthcheck:
@@ -37,3 +42,4 @@ services:
 
 volumes:
   postgres-data:
+  app-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       LOG_LEVEL: DEBUG
       API_KEY: pfs_test_key_for_development_only
     volumes:
-      - ~/.polar-flow:/root/.polar-flow
+      - ~/.polar-flow:/data/keys  # KEY_DIR — reuse host keys in dev
       - ./src:/app/src  # Mount source for hot reload
       - ./alembic:/app/alembic  # Mount alembic for migrations
       - ./alembic.ini:/app/alembic.ini  # Mount alembic config

--- a/src/polar_flow_server/app.py
+++ b/src/polar_flow_server/app.py
@@ -25,6 +25,7 @@ from polar_flow_server.core.database import (
     engine,
     init_database,
 )
+from polar_flow_server.core.security import verify_stored_tokens_decryptable
 from polar_flow_server.middleware import RateLimitHeadersMiddleware
 from polar_flow_server.routes import root_redirect
 from polar_flow_server.services.scheduler import SyncScheduler, set_scheduler
@@ -69,6 +70,14 @@ async def lifespan(app: Litestar) -> AsyncIterator[None]:
     # Initialize database tables
     await init_database()
     logger.info("Database initialized")
+
+    # Detect encryption-key drift early (lost key file = every stored Polar
+    # token is unreadable) rather than failing silently at the next sync.
+    try:
+        async with async_session_maker() as check_session:
+            await verify_stored_tokens_decryptable(check_session)
+    except Exception as exc:  # pragma: no cover - never block startup on the check
+        logger.warning("Token decryptability check failed to run", error=str(exc))
 
     # Start background sync scheduler
     scheduler = SyncScheduler(async_session_maker)

--- a/src/polar_flow_server/core/config.py
+++ b/src/polar_flow_server/core/config.py
@@ -1,11 +1,14 @@
 """Application configuration."""
 
+import logging
 from enum import Enum
 from pathlib import Path
 from typing import Literal
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
 
 
 class DeploymentMode(str, Enum):
@@ -61,6 +64,12 @@ class Settings(BaseSettings):
     session_secret: str | None = Field(
         default=None,
         description="Secret key for session cookies (auto-generated if not set)",
+    )
+    key_dir: Path = Field(
+        default_factory=lambda: Path.home() / ".polar-flow",
+        description="Directory where auto-generated encryption/session keys are persisted. "
+        "In Docker this MUST live on a persistent volume, or every redeploy regenerates "
+        "the keys and stored Polar tokens become undecryptable.",
     )
     jwt_secret: str | None = Field(
         default=None,
@@ -127,10 +136,27 @@ class Settings(BaseSettings):
         """Check if running in SaaS mode."""
         return self.deployment_mode == DeploymentMode.SAAS
 
+    def _key_file(self, name: str) -> Path:
+        """Resolve a key file inside key_dir, migrating from the legacy location.
+
+        Keys used to live in ~/.polar-flow unconditionally. If key_dir points
+        somewhere else (e.g. /data/keys in Docker) and the file only exists at
+        the legacy path, copy it across so existing installs keep their keys.
+        """
+        key_file = self.key_dir / name
+        key_file.parent.mkdir(parents=True, exist_ok=True)
+
+        legacy_file = Path.home() / ".polar-flow" / name
+        if not key_file.exists() and legacy_file != key_file and legacy_file.exists():
+            key_file.write_bytes(legacy_file.read_bytes())
+            key_file.chmod(0o600)
+            logger.info("Migrated %s from legacy location %s to %s", name, legacy_file, key_file)
+        return key_file
+
     def get_encryption_key(self) -> bytes:
         """Get encryption key for Polar tokens.
 
-        In self-hosted mode, generates and persists key to ~/.polar-flow/encryption.key
+        In self-hosted mode, generates and persists key to <key_dir>/encryption.key
         to ensure tokens survive server restarts.
 
         Raises:
@@ -142,14 +168,9 @@ class Settings(BaseSettings):
         if self.is_saas():
             raise ValueError("ENCRYPTION_KEY must be set in SaaS mode")
 
-        # Self-hosted: persist key to file so tokens survive restarts
-        from pathlib import Path
-
         from cryptography.fernet import Fernet
 
-        key_file = Path.home() / ".polar-flow" / "encryption.key"
-        key_file.parent.mkdir(parents=True, exist_ok=True)
-
+        key_file = self._key_file("encryption.key")
         if key_file.exists():
             return key_file.read_bytes().strip()
 
@@ -157,12 +178,19 @@ class Settings(BaseSettings):
         key = Fernet.generate_key()
         key_file.write_bytes(key)
         key_file.chmod(0o600)  # Owner read/write only
+        logger.warning(
+            "Generated a NEW token encryption key at %s. If Polar accounts were connected "
+            "before, their stored tokens can no longer be decrypted and each account must "
+            "re-authorize. Persist this file (or set ENCRYPTION_KEY) so this cannot happen "
+            "again — in Docker, mount a volume over the key directory.",
+            key_file,
+        )
         return key
 
     def get_session_secret(self) -> str:
         """Get session secret for admin cookies.
 
-        In self-hosted mode, generates and persists secret to ~/.polar-flow/session.key
+        In self-hosted mode, generates and persists secret to <key_dir>/session.key
         to ensure sessions survive server restarts.
         """
         if self.session_secret:
@@ -170,11 +198,8 @@ class Settings(BaseSettings):
 
         # Self-hosted: persist secret to file so sessions survive restarts
         import secrets
-        from pathlib import Path
 
-        secret_file = Path.home() / ".polar-flow" / "session.key"
-        secret_file.parent.mkdir(parents=True, exist_ok=True)
-
+        secret_file = self._key_file("session.key")
         if secret_file.exists():
             return secret_file.read_text().strip()
 
@@ -182,6 +207,12 @@ class Settings(BaseSettings):
         secret = secrets.token_urlsafe(32)
         secret_file.write_text(secret)
         secret_file.chmod(0o600)  # Owner read/write only
+        logger.warning(
+            "Generated a new session secret at %s — all existing admin sessions are now "
+            "invalid. Persist this file (or set SESSION_SECRET) to keep sessions across "
+            "restarts.",
+            secret_file,
+        )
         return secret
 
 

--- a/src/polar_flow_server/core/security.py
+++ b/src/polar_flow_server/core/security.py
@@ -1,8 +1,14 @@
 """Security utilities for token encryption."""
 
-from cryptography.fernet import Fernet
+import logging
+
+from cryptography.fernet import Fernet, InvalidToken
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from polar_flow_server.core.config import settings
+
+logger = logging.getLogger(__name__)
 
 
 class TokenEncryption:
@@ -38,3 +44,37 @@ class TokenEncryption:
 
 # Global instance
 token_encryption = TokenEncryption()
+
+
+async def verify_stored_tokens_decryptable(session: AsyncSession) -> bool:
+    """Check that stored Polar tokens decrypt with the current encryption key.
+
+    Called at startup. If the key has changed (e.g. a redeploy regenerated it
+    because the key directory was not persisted), every stored token is
+    unreadable and each Polar account must re-authorize — say so loudly
+    instead of failing silently at the next sync.
+
+    Returns True if tokens are healthy (or none are stored), False on mismatch.
+    """
+    from polar_flow_server.models.user import User
+
+    result = await session.execute(select(User.access_token_encrypted).limit(5))
+    healthy = True
+    for (encrypted,) in result:
+        if encrypted is None:
+            continue
+        try:
+            token_encryption.decrypt(encrypted)
+        except (InvalidToken, ValueError):
+            healthy = False
+            break
+    if not healthy:
+        logger.critical(
+            "ENCRYPTION KEY MISMATCH: stored Polar tokens cannot be decrypted with the "
+            "current encryption key. This usually means the key file was lost in a "
+            "redeploy (key directory not on a persistent volume) and a new key was "
+            "generated. Every connected Polar account must re-authorize via the admin "
+            "panel. To prevent recurrence, persist the key directory or set "
+            "ENCRYPTION_KEY explicitly."
+        )
+    return healthy

--- a/tests/test_key_persistence.py
+++ b/tests/test_key_persistence.py
@@ -1,0 +1,141 @@
+"""Tests for encryption/session key persistence (issue #50).
+
+Covers: key generation + reuse under KEY_DIR, env-var override, migration
+from the legacy ~/.polar-flow location, generation warnings, and the startup
+check that detects an encryption-key/stored-token mismatch.
+"""
+
+import logging
+
+import pytest
+from cryptography.fernet import Fernet
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from polar_flow_server.core.config import Settings
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    """Point HOME at a temp dir so tests never touch the real ~/.polar-flow."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    return home
+
+
+class TestEncryptionKeyPersistence:
+    def test_generates_and_persists_key(self, tmp_path, isolated_home):
+        settings = Settings(key_dir=tmp_path / "keys")
+        key = settings.get_encryption_key()
+
+        key_file = tmp_path / "keys" / "encryption.key"
+        assert key_file.exists()
+        assert key_file.read_bytes().strip() == key
+        assert key_file.stat().st_mode & 0o777 == 0o600
+        # Must be a valid Fernet key
+        Fernet(key)
+
+    def test_reuses_existing_key(self, tmp_path, isolated_home):
+        settings = Settings(key_dir=tmp_path / "keys")
+        first = settings.get_encryption_key()
+        second = Settings(key_dir=tmp_path / "keys").get_encryption_key()
+        assert first == second
+
+    def test_env_override_wins(self, tmp_path, isolated_home):
+        explicit = Fernet.generate_key().decode()
+        settings = Settings(key_dir=tmp_path / "keys", encryption_key=explicit)
+        assert settings.get_encryption_key() == explicit.encode()
+        # Nothing written to disk when the key comes from config
+        assert not (tmp_path / "keys" / "encryption.key").exists()
+
+    def test_migrates_key_from_legacy_location(self, tmp_path, isolated_home):
+        legacy_dir = isolated_home / ".polar-flow"
+        legacy_dir.mkdir()
+        legacy_key = Fernet.generate_key()
+        (legacy_dir / "encryption.key").write_bytes(legacy_key)
+
+        settings = Settings(key_dir=tmp_path / "new-keys")
+        assert settings.get_encryption_key() == legacy_key
+        # Copied to the new location for future reads
+        assert (tmp_path / "new-keys" / "encryption.key").read_bytes() == legacy_key
+
+    def test_default_key_dir_is_home_no_migration_noise(self, isolated_home):
+        # Default key_dir == legacy path: generation works, no self-migration
+        settings = Settings()
+        key = settings.get_encryption_key()
+        assert (isolated_home / ".polar-flow" / "encryption.key").read_bytes().strip() == key
+
+    def test_warns_on_fresh_generation(self, tmp_path, isolated_home, caplog):
+        settings = Settings(key_dir=tmp_path / "keys")
+        with caplog.at_level(logging.WARNING, logger="polar_flow_server.core.config"):
+            settings.get_encryption_key()
+        assert any("NEW token encryption key" in r.message for r in caplog.records)
+
+        # Reuse must NOT warn
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="polar_flow_server.core.config"):
+            Settings(key_dir=tmp_path / "keys").get_encryption_key()
+        assert not caplog.records
+
+
+class TestSessionSecretPersistence:
+    def test_generates_and_persists_secret(self, tmp_path, isolated_home):
+        settings = Settings(key_dir=tmp_path / "keys")
+        secret = settings.get_session_secret()
+        secret_file = tmp_path / "keys" / "session.key"
+        assert secret_file.read_text().strip() == secret
+        assert secret_file.stat().st_mode & 0o777 == 0o600
+        assert Settings(key_dir=tmp_path / "keys").get_session_secret() == secret
+
+    def test_env_override_wins(self, tmp_path, isolated_home):
+        settings = Settings(key_dir=tmp_path / "keys", session_secret="explicit-secret")
+        assert settings.get_session_secret() == "explicit-secret"
+        assert not (tmp_path / "keys" / "session.key").exists()
+
+    def test_migrates_secret_from_legacy_location(self, tmp_path, isolated_home):
+        legacy_dir = isolated_home / ".polar-flow"
+        legacy_dir.mkdir()
+        (legacy_dir / "session.key").write_text("legacy-secret\n")
+
+        settings = Settings(key_dir=tmp_path / "new-keys")
+        assert settings.get_session_secret() == "legacy-secret"
+
+
+class TestStartupTokenCheck:
+    async def _add_user(self, session: AsyncSession, encrypted: str) -> None:
+        from polar_flow_server.models.user import User
+
+        session.add(
+            User(
+                id="key-check-user",
+                polar_user_id="polar_key_check",
+                access_token_encrypted=encrypted,
+                is_active=True,
+            )
+        )
+        await session.commit()
+
+    async def test_healthy_when_no_users(self, async_session: AsyncSession):
+        from polar_flow_server.core.security import verify_stored_tokens_decryptable
+
+        assert await verify_stored_tokens_decryptable(async_session) is True
+
+    async def test_healthy_when_tokens_decrypt(self, async_session: AsyncSession):
+        from polar_flow_server.core.security import (
+            token_encryption,
+            verify_stored_tokens_decryptable,
+        )
+
+        await self._add_user(async_session, token_encryption.encrypt("real-token"))
+        assert await verify_stored_tokens_decryptable(async_session) is True
+
+    async def test_critical_log_on_key_mismatch(self, async_session: AsyncSession, caplog):
+        from polar_flow_server.core.security import verify_stored_tokens_decryptable
+
+        # Token encrypted with a DIFFERENT key than the current global cipher
+        other_cipher = Fernet(Fernet.generate_key())
+        await self._add_user(async_session, other_cipher.encrypt(b"real-token").decode())
+
+        with caplog.at_level(logging.CRITICAL, logger="polar_flow_server.core.security"):
+            assert await verify_stored_tokens_decryptable(async_session) is False
+        assert any("ENCRYPTION KEY MISMATCH" in r.message for r in caplog.records)


### PR DESCRIPTION
Closes #50.

## Problem
`docker-compose.prod.yml` mounted no volume for the key directory, so every redeploy regenerated the Fernet key — permanently orphaning all stored Polar OAuth tokens and invalidating sessions, silently.

## Changes
- **New `KEY_DIR` setting** (default `~/.polar-flow`, unchanged for bare metal). The Docker image sets `KEY_DIR=/data/keys` and the prod compose now mounts `app-data:/data`, so keys survive recreates.
- **Legacy migration**: if a key exists at `~/.polar-flow` but not in `KEY_DIR`, it's copied across on first read — dev-compose users who mounted `~/.polar-flow` keep their keys (dev compose mount updated to target `/data/keys`).
- **Loud generation warnings**: generating a fresh encryption key or session secret now logs a WARNING explaining the consequences and the fix.
- **Startup mismatch check**: on boot we try to decrypt a few stored tokens; a key mismatch logs CRITICAL with re-auth instructions instead of failing silently at the next sync. Never blocks startup.
- `.env.example` documents `ENCRYPTION_KEY` / `SESSION_SECRET` / `KEY_DIR` (including how to generate a Fernet key) for operators who manage secrets externally.

## Upgrade notes
Existing prod deployments already lose the key on every image upgrade, so moving the default path inside the container loses nothing extra — but after this release the key finally sticks. Users will need one final re-auth if their key was ephemeral.

## Testing
- 12 new tests in `tests/test_key_persistence.py`: generation + 0600 perms, reuse, env override, legacy migration (both keys), no-warning-on-reuse, startup check healthy/mismatch paths (mismatch asserts the CRITICAL log).
- Full suite: **96 passed** (84 baseline + 12 new). mypy clean on changed files; the one ruff finding (`UP042` on `DeploymentMode`) pre-exists on main.