### PR TITLE
fix: re-enable CSRF on destructive admin POSTs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,23 @@ jobs:
       matrix:
         python-version: ["3.12", "3.13"]
 
+    services:
+      # Integration tests (app_client fixture) run the real app against this.
+      # Credentials must match the URL hardcoded in tests/conftest.py.
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: polar
+          POSTGRES_PASSWORD: polar
+          POSTGRES_DB: polar_test
+        ports:
+          - "5432:5432"
+        options: >-
+          --health-cmd "pg_isready -U polar"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - uses: actions/checkout@v7
 

--- a/src/polar_flow_server/app.py
+++ b/src/polar_flow_server/app.py
@@ -127,12 +127,6 @@ def create_app() -> Litestar:
             "/oauth/",  # SaaS OAuth flow (callback, exchange, start)
             # Safe to exclude (just destroys session)
             "/admin/logout",
-            # Admin API key management (session-authenticated, CSRF handled by JS)
-            # TODO: Debug why CSRF validation fails even with correct token
-            "/admin/api-keys/",
-            # Admin sync and settings (HTMX sends CSRF token)
-            "/admin/sync",
-            "/admin/settings",
             # API routes use API key auth, not CSRF
             "/api/v1/users/",
             # Health check (no auth needed)

--- a/src/polar_flow_server/core/config.py
+++ b/src/polar_flow_server/core/config.py
@@ -48,6 +48,12 @@ class Settings(BaseSettings):
         default="postgresql+asyncpg://polar:polar@localhost:5432/polar",
         description="PostgreSQL database URL",
     )
+    database_pool: Literal["default", "null"] = Field(
+        default="default",
+        description="Connection pooling strategy: 'default' (pooled) or 'null' "
+        "(fresh connection per use; needed when the app runs across event loops, "
+        "e.g. under the integration test client)",
+    )
 
     # Security
     api_key: str | None = Field(

--- a/src/polar_flow_server/core/database.py
+++ b/src/polar_flow_server/core/database.py
@@ -23,6 +23,14 @@ def create_engine() -> AsyncEngine:
     Returns:
         Async SQLAlchemy engine configured for PostgreSQL
     """
+    if settings.database_pool == "null":
+        # No connection pooling: each checkout opens a fresh connection.
+        # Required when connections would otherwise be shared across event
+        # loops (the integration test client runs the app in its own loop).
+        from sqlalchemy.pool import NullPool
+
+        return create_async_engine(settings.database_url, echo=False, poolclass=NullPool)
+
     return create_async_engine(
         settings.database_url,
         echo=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,21 @@
 """Shared test fixtures."""
 
 import asyncio
+import os
 from collections.abc import AsyncIterator, Iterator
 from datetime import UTC, datetime, timedelta
+
+# Integration tests (the `app_client` fixture) run the REAL app — lifespan,
+# middleware, DI — against a dedicated Postgres database so they can never
+# touch a developer's actual data. Must be set before any polar_flow_server
+# import so the global Settings/engine pick it up. CI provides the matching
+# postgres service container (see .github/workflows/tests.yml).
+os.environ["DATABASE_URL"] = "postgresql+asyncpg://polar:polar@localhost:5432/polar_test"
+os.environ["SYNC_ENABLED"] = "false"
+os.environ["SYNC_ON_STARTUP"] = "false"
+# The test client runs the app in its own event loop (anyio portal); pooled
+# asyncpg connections cannot cross loops, so use a fresh connection per use.
+os.environ["DATABASE_POOL"] = "null"
 
 import pytest
 from sqlalchemy import event
@@ -194,3 +207,59 @@ async def analytics_user_3d(async_session: AsyncSession, test_user):
         days=3,
     )
     return test_user, counts
+
+
+# =============================================================================
+# Integration fixtures — the real app (lifespan, middleware, DI) against the
+# dedicated polar_test Postgres database. Skipped automatically if Postgres
+# is unreachable so unit tests still run anywhere.
+# =============================================================================
+
+
+@pytest.fixture
+async def app_client():
+    """Full-stack test client: real app with lifespan against polar_test."""
+    from litestar.testing import AsyncTestClient
+    from sqlalchemy.exc import OperationalError
+
+    import polar_flow_server.models  # noqa: F401 - register all models on Base
+    from polar_flow_server.app import create_app
+    from polar_flow_server.core.database import engine
+    from polar_flow_server.models.base import Base
+
+    # pytest-asyncio gives every test its own event loop, but the app engine
+    # is a module-level global — dispose its pool so connections are always
+    # created in the current loop (stale ones raise InterfaceError).
+    await engine.dispose()
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+            await conn.run_sync(Base.metadata.create_all)
+    except (OperationalError, OSError) as exc:  # pragma: no cover
+        pytest.skip(f"Postgres test database unavailable: {exc}")
+
+    try:
+        async with AsyncTestClient(app=create_app()) as client:
+            yield client
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+async def admin_account(app_client):
+    """Create an admin user directly in the test database."""
+    from polar_flow_server.core.database import async_session_maker
+    from polar_flow_server.core.password import hash_password
+    from polar_flow_server.models.admin_user import AdminUser
+
+    credentials = {"email": "admin@example.com", "password": "correct-horse-battery"}
+    async with async_session_maker() as session:
+        session.add(
+            AdminUser(
+                email=credentials["email"],
+                password_hash=hash_password(credentials["password"]),
+                is_active=True,
+            )
+        )
+        await session.commit()
+    return credentials

--- a/tests/test_admin_csrf.py
+++ b/tests/test_admin_csrf.py
@@ -88,9 +88,7 @@ class TestCsrfAllowsLegitimateRequests:
     async def test_api_key_create_with_token(self, app_client, admin_account):
         token = await _get_csrf_token(app_client)
         await _login(app_client, admin_account)
-        response = await app_client.post(
-            "/admin/api-keys/create", headers={"X-CSRF-Token": token}
-        )
+        response = await app_client.post("/admin/api-keys/create", headers={"X-CSRF-Token": token})
         assert response.status_code == HTTP_200_OK
         assert "Authentication required" not in response.text
 

--- a/tests/test_admin_csrf.py
+++ b/tests/test_admin_csrf.py
@@ -1,0 +1,104 @@
+"""CSRF enforcement tests for destructive admin POSTs (issue #53).
+
+These run the real app (middleware included) via the app_client fixture, so
+they prove both directions: forged requests are rejected AND the legitimate
+frontend flows (HTMX header, hidden form field) still work.
+"""
+
+import pytest
+from litestar.status_codes import HTTP_200_OK, HTTP_403_FORBIDDEN
+
+DESTRUCTIVE_POSTS = [
+    "/admin/sync",
+    "/admin/settings/reset-oauth",
+    "/admin/api-keys/create",
+]
+
+
+async def _get_csrf_token(app_client) -> str:
+    """Fetch /admin so the CSRF middleware sets the cookie.
+
+    Note: paths in the CSRF exclude list (like /admin/login) are skipped by
+    the middleware entirely, so they never SET the cookie either. Browsers
+    always arrive via /admin (redirect to login/setup), which does set it.
+    """
+    response = await app_client.get("/admin", follow_redirects=False)
+    assert response.status_code in (200, 303)
+    token = app_client.cookies.get("csrf_token")
+    assert token, "CSRF middleware should set csrf_token cookie on GET /admin"
+    return token
+
+
+async def _login(app_client, admin_account) -> None:
+    response = await app_client.post(
+        "/admin/login",
+        data={"email": admin_account["email"], "password": admin_account["password"]},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303, "login should succeed and redirect"
+
+
+class TestCsrfRejectsForgedRequests:
+    @pytest.mark.parametrize("path", DESTRUCTIVE_POSTS)
+    async def test_post_without_token_is_forbidden(self, app_client, path):
+        response = await app_client.post(path)
+        assert response.status_code == HTTP_403_FORBIDDEN
+
+    @pytest.mark.parametrize("path", DESTRUCTIVE_POSTS)
+    async def test_post_with_wrong_token_is_forbidden(self, app_client, path):
+        await _get_csrf_token(app_client)
+        response = await app_client.post(path, headers={"X-CSRF-Token": "forged-token"})
+        assert response.status_code == HTTP_403_FORBIDDEN
+
+    async def test_logged_in_session_alone_is_not_enough(self, app_client, admin_account):
+        """The actual CSRF attack shape: valid session, no token."""
+        await _get_csrf_token(app_client)
+        await _login(app_client, admin_account)
+        # Simulate a cross-site request: cookies ride along, header does not
+        response = await app_client.post("/admin/sync")
+        assert response.status_code == HTTP_403_FORBIDDEN
+
+
+class TestCsrfAllowsLegitimateRequests:
+    async def test_header_token_reaches_handler(self, app_client):
+        """X-CSRF-Token header (what base.html's HTMX hook + settings.html send)."""
+        token = await _get_csrf_token(app_client)
+        response = await app_client.post("/admin/sync", headers={"X-CSRF-Token": token})
+        # Handler ran (returns the auth-required partial, not a 403)
+        assert response.status_code == HTTP_200_OK
+        assert "Authentication required" in response.text
+
+    async def test_form_field_token_reaches_handler(self, app_client):
+        """_csrf_token hidden input (what dashboard.html forms send)."""
+        token = await _get_csrf_token(app_client)
+        response = await app_client.post("/admin/sync", data={"_csrf_token": token})
+        assert response.status_code == HTTP_200_OK
+        assert "Authentication required" in response.text
+
+    async def test_full_flow_login_then_sync(self, app_client, admin_account):
+        """End to end: login, then trigger sync with the token like the UI does."""
+        token = await _get_csrf_token(app_client)
+        await _login(app_client, admin_account)
+        response = await app_client.post("/admin/sync", headers={"X-CSRF-Token": token})
+        assert response.status_code == HTTP_200_OK
+        # Authenticated: past the auth check, into the no-Polar-user-yet branch
+        assert "Authentication required" not in response.text
+        assert "No user configured" in response.text
+
+    async def test_api_key_create_with_token(self, app_client, admin_account):
+        token = await _get_csrf_token(app_client)
+        await _login(app_client, admin_account)
+        response = await app_client.post(
+            "/admin/api-keys/create", headers={"X-CSRF-Token": token}
+        )
+        assert response.status_code == HTTP_200_OK
+        assert "Authentication required" not in response.text
+
+    async def test_login_stays_excluded(self, app_client):
+        """Login must work with no prior CSRF cookie (entry point)."""
+        response = await app_client.post(
+            "/admin/login",
+            data={"email": "nobody@example.com", "password": "wrong"},
+            follow_redirects=False,
+        )
+        assert response.status_code != HTTP_403_FORBIDDEN


### PR DESCRIPTION
Closes #53.

## Problem
The CSRF `exclude` list exempted `/admin/api-keys/` (create/revoke/regenerate), `/admin/sync`, and `/admin/settings` (whose prefix also exempts `/admin/settings/reset-oauth`) with a `TODO: Debug why CSRF validation fails even with correct token`. Any site you visit while logged in could fire those POSTs.

## Root cause of the old TODO
Litestar's CSRF middleware skips excluded paths **entirely** — including setting the `csrf_token` cookie on responses. So a flow that started on an excluded page (login, setup) had no cookie, templates rendered no token, and the first non-excluded POST failed 'even with the correct token' — there wasn't one. The template plumbing (HTMX `htmx:configRequest` hook in `base.html`, explicit `X-CSRF-Token` headers in `settings.html`, hidden `_csrf_token` inputs) was always correct. In real browser flows the cookie is set by the `/admin` redirect before the user ever submits anything, so removing the exclusions just works.

## Changes
- Removed the three exclusions; login/setup/oauth-callback/logout/API/health remain excluded (entry points and non-cookie auth).
- **New integration-test infrastructure** (first app-level tests in the repo):
  - postgres service container in `tests.yml` + dedicated `polar_test` database so tests can never touch real data
  - `app_client` conftest fixture running the real app — lifespan, middleware, DI — and skipping gracefully if postgres is absent
  - `DATABASE_POOL=null` setting: the test client runs the app in its own event loop, and pooled asyncpg connections cannot cross loops (SQLAlchemy's documented NullPool case). Prod behaviour unchanged.

## Testing
12 new tests in `tests/test_admin_csrf.py`, both directions:
- forged: no token → 403, wrong token → 403, and the real attack shape — **valid logged-in session, missing header → 403**
- legitimate: header token reaches handler, form-field token reaches handler, full login→sync flow 200, api-key create 200, login still works with no prior cookie

Full suite: **96 passed** (84 baseline + 12). mypy clean; the single ruff finding (UP042) pre-exists on main.

## Note for a follow-up
`/admin/setup` (prefix) still exempts `POST /admin/setup/oauth`, which a logged-in admin can be CSRF'd on. Deliberately out of scope here — the setup flow gets reworked in #52 and that exclusion should be tightened there.