### PR TITLE
fix: login rate limiter is neutralised (and spoofable) behind a reverse proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,13 @@ DATABASE_URL=postgresql+asyncpg://polar:polar@postgres:5432/polar
 # In Docker this directory MUST be on a persistent volume — losing the
 # encryption key makes all stored Polar tokens permanently undecryptable.
 # KEY_DIR=/data/keys
+# Reverse proxies whose X-Forwarded-For/X-Real-IP headers are trusted when
+# working out the real client IP (login rate limiting). Comma-separated IPs or
+# CIDRs. If your reverse proxy runs in another Docker container, add its
+# network here or every client appears as one shared IP and 5 failed logins
+# from ANYONE lock out the admin panel for everyone.
+#   docker network inspect <network> | grep Subnet   # find the value
+# TRUSTED_PROXIES=127.0.0.1,::1,172.16.0.0/12
 
 # Sync settings
 SYNC_ENABLED=true                    # Enable/disable automatic background syncing

--- a/src/polar_flow_server/admin/routes.py
+++ b/src/polar_flow_server/admin/routes.py
@@ -9,6 +9,7 @@ import re
 import secrets
 from collections import OrderedDict
 from datetime import UTC, date, datetime, timedelta
+from ipaddress import IPv4Network, IPv6Network, ip_address, ip_network
 from typing import Any
 from urllib.parse import urlencode
 
@@ -493,28 +494,63 @@ async def login_form(request: Request[Any, Any, Any], session: AsyncSession) -> 
     )
 
 
-def _get_client_ip(request: Request[Any, Any, Any]) -> str:
-    """Get client IP from request, checking proxy headers only from trusted sources.
+def _trusted_proxy_matchers() -> tuple[set[str], list[IPv4Network | IPv6Network]]:
+    """Parse settings.trusted_proxies into literal hosts and IP networks."""
+    literals: set[str] = set()
+    networks: list[IPv4Network | IPv6Network] = []
+    for entry in settings.trusted_proxies.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        try:
+            networks.append(ip_network(entry, strict=False))
+        except ValueError:
+            # Not an IP/CIDR — treat as a literal peer name (e.g. "localhost")
+            literals.add(entry)
+    return literals, networks
 
-    Only trusts X-Forwarded-For/X-Real-IP when request comes from localhost
-    (i.e., from a reverse proxy like nginx/Coolify running on the same host).
-    This prevents IP spoofing attacks where attackers set fake headers.
+
+def _is_trusted_proxy(host: str) -> bool:
+    literals, networks = _trusted_proxy_matchers()
+    if host in literals:
+        return True
+    try:
+        addr = ip_address(host)
+    except ValueError:
+        return False
+    return any(addr in network for network in networks)
+
+
+def _get_client_ip(request: Request[Any, Any, Any]) -> str:
+    """Get the real client IP, honouring proxy headers only from trusted proxies.
+
+    The direct peer must be in TRUSTED_PROXIES (IPs/CIDRs, e.g. the Docker
+    network the reverse proxy lives on) for X-Forwarded-For/X-Real-IP to be
+    considered at all. X-Forwarded-For is then walked right-to-left, skipping
+    trusted proxies: the first untrusted hop is the client. Never take the
+    leftmost entry — clients can prepend arbitrary values before the proxy
+    appends the real address, which would let an attacker pick their own
+    identity (dodging rate limits or locking out a victim's IP).
     """
     client = request.client
     direct_ip = client.host if client else "unknown"
 
-    # Only trust proxy headers if request comes from localhost (reverse proxy)
-    trusted_proxies = {"127.0.0.1", "::1", "localhost"}
-    if direct_ip in trusted_proxies:
-        # Check X-Forwarded-For header (set by proxies like nginx, Coolify)
-        forwarded_for = request.headers.get("x-forwarded-for")
-        if forwarded_for:
-            # Take the first IP (original client)
-            return forwarded_for.split(",")[0].strip()
-        # Check X-Real-IP header
-        real_ip = request.headers.get("x-real-ip")
-        if real_ip:
-            return real_ip
+    if not _is_trusted_proxy(direct_ip):
+        return direct_ip
+
+    forwarded_for = request.headers.get("x-forwarded-for", "")
+    hops = [hop.strip() for hop in forwarded_for.split(",") if hop.strip()]
+    for hop in reversed(hops):
+        if not _is_trusted_proxy(hop):
+            return hop
+    if hops:
+        # Every hop is a trusted proxy — the innermost is the closest to a client
+        return hops[0]
+
+    # X-Real-IP is set (not appended) by the proxy itself, safe from trusted peers
+    real_ip = request.headers.get("x-real-ip")
+    if real_ip:
+        return real_ip.strip()
 
     return direct_ip
 

--- a/src/polar_flow_server/core/config.py
+++ b/src/polar_flow_server/core/config.py
@@ -76,6 +76,7 @@ class Settings(BaseSettings):
         description="Directory where auto-generated encryption/session keys are persisted. "
         "In Docker this MUST live on a persistent volume, or every redeploy regenerates "
         "the keys and stored Polar tokens become undecryptable.",
+    )
     trusted_proxies: str = Field(
         default="127.0.0.1,::1",
         description="Comma-separated IPs/CIDRs of reverse proxies whose "

--- a/src/polar_flow_server/core/config.py
+++ b/src/polar_flow_server/core/config.py
@@ -76,6 +76,12 @@ class Settings(BaseSettings):
         description="Directory where auto-generated encryption/session keys are persisted. "
         "In Docker this MUST live on a persistent volume, or every redeploy regenerates "
         "the keys and stored Polar tokens become undecryptable.",
+    trusted_proxies: str = Field(
+        default="127.0.0.1,::1",
+        description="Comma-separated IPs/CIDRs of reverse proxies whose "
+        "X-Forwarded-For/X-Real-IP headers are trusted for client IP detection "
+        "(e.g. '127.0.0.1,::1,172.16.0.0/12' when the proxy is another Docker "
+        "container). Requests from other peers use the direct socket address.",
     )
     jwt_secret: str | None = Field(
         default=None,

--- a/tests/test_client_ip.py
+++ b/tests/test_client_ip.py
@@ -46,9 +46,7 @@ class TestGetClientIp:
         """Attacker sends their own XFF; the proxy appends the real address.
         The rightmost untrusted hop wins, never the attacker-chosen first."""
         trusted("127.0.0.1,::1")
-        request = _request(
-            "127.0.0.1", {"X-Forwarded-For": "6.6.6.6, 203.0.113.9"}
-        )
+        request = _request("127.0.0.1", {"X-Forwarded-For": "6.6.6.6, 203.0.113.9"})
         assert _get_client_ip(request) == "203.0.113.9"
 
     def test_docker_network_cidr(self, trusted):
@@ -59,9 +57,7 @@ class TestGetClientIp:
 
     def test_chained_trusted_proxies_are_skipped(self, trusted):
         trusted("127.0.0.1,172.16.0.0/12")
-        request = _request(
-            "172.18.0.5", {"X-Forwarded-For": "203.0.113.9, 172.18.0.2"}
-        )
+        request = _request("172.18.0.5", {"X-Forwarded-For": "203.0.113.9, 172.18.0.2"})
         assert _get_client_ip(request) == "203.0.113.9"
 
     def test_all_hops_trusted_returns_innermost(self, trusted):

--- a/tests/test_client_ip.py
+++ b/tests/test_client_ip.py
@@ -1,0 +1,167 @@
+"""Client IP detection + login rate limiter attribution tests (issue #51).
+
+Unit tests drive _get_client_ip directly with stub requests; the integration
+tests prove the two real-world failure modes end to end:
+- behind an untrusted peer, X-Forwarded-For spoofing is ignored
+- behind a trusted proxy, distinct clients get distinct rate-limit buckets,
+  so an attacker's failures no longer lock out the real admin (lockout DoS)
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from polar_flow_server.admin import routes
+from polar_flow_server.admin.routes import LoginRateLimiter, _get_client_ip
+from polar_flow_server.core.config import settings
+
+
+def _request(peer: str, headers: dict[str, str] | None = None):
+    return SimpleNamespace(
+        client=SimpleNamespace(host=peer),
+        headers={k.lower(): v for k, v in (headers or {}).items()},
+    )
+
+
+@pytest.fixture
+def trusted(monkeypatch):
+    def set_value(value: str) -> None:
+        monkeypatch.setattr(settings, "trusted_proxies", value)
+
+    return set_value
+
+
+class TestGetClientIp:
+    def test_untrusted_peer_ignores_spoofed_xff(self, trusted):
+        trusted("127.0.0.1,::1")
+        request = _request("203.0.113.9", {"X-Forwarded-For": "10.0.0.1"})
+        assert _get_client_ip(request) == "203.0.113.9"
+
+    def test_trusted_localhost_uses_xff(self, trusted):
+        trusted("127.0.0.1,::1")
+        request = _request("127.0.0.1", {"X-Forwarded-For": "203.0.113.9"})
+        assert _get_client_ip(request) == "203.0.113.9"
+
+    def test_client_prepended_junk_is_not_believed(self, trusted):
+        """Attacker sends their own XFF; the proxy appends the real address.
+        The rightmost untrusted hop wins, never the attacker-chosen first."""
+        trusted("127.0.0.1,::1")
+        request = _request(
+            "127.0.0.1", {"X-Forwarded-For": "6.6.6.6, 203.0.113.9"}
+        )
+        assert _get_client_ip(request) == "203.0.113.9"
+
+    def test_docker_network_cidr(self, trusted):
+        """The shipped deployment: reverse proxy is another container."""
+        trusted("127.0.0.1,::1,172.16.0.0/12")
+        request = _request("172.18.0.5", {"X-Forwarded-For": "203.0.113.9"})
+        assert _get_client_ip(request) == "203.0.113.9"
+
+    def test_chained_trusted_proxies_are_skipped(self, trusted):
+        trusted("127.0.0.1,172.16.0.0/12")
+        request = _request(
+            "172.18.0.5", {"X-Forwarded-For": "203.0.113.9, 172.18.0.2"}
+        )
+        assert _get_client_ip(request) == "203.0.113.9"
+
+    def test_all_hops_trusted_returns_innermost(self, trusted):
+        trusted("127.0.0.1,172.16.0.0/12")
+        request = _request("172.18.0.5", {"X-Forwarded-For": "172.18.0.7, 172.18.0.2"})
+        assert _get_client_ip(request) == "172.18.0.7"
+
+    def test_x_real_ip_fallback_from_trusted_peer(self, trusted):
+        trusted("127.0.0.1")
+        request = _request("127.0.0.1", {"X-Real-IP": "203.0.113.9"})
+        assert _get_client_ip(request) == "203.0.113.9"
+
+    def test_x_real_ip_ignored_from_untrusted_peer(self, trusted):
+        trusted("127.0.0.1")
+        request = _request("203.0.113.50", {"X-Real-IP": "10.0.0.1"})
+        assert _get_client_ip(request) == "203.0.113.50"
+
+    def test_no_headers_returns_peer(self, trusted):
+        trusted("127.0.0.1,::1")
+        assert _get_client_ip(_request("127.0.0.1")) == "127.0.0.1"
+
+    def test_ipv6_localhost_trusted(self, trusted):
+        trusted("127.0.0.1,::1")
+        request = _request("::1", {"X-Forwarded-For": "2001:db8::9"})
+        assert _get_client_ip(request) == "2001:db8::9"
+
+    def test_invalid_config_entry_is_not_fatal(self, trusted):
+        trusted("127.0.0.1,not-a-cidr/99")
+        request = _request("127.0.0.1", {"X-Forwarded-For": "203.0.113.9"})
+        assert _get_client_ip(request) == "203.0.113.9"
+
+    def test_literal_hostname_entry(self, trusted):
+        """Non-IP entries match the peer string literally (e.g. 'localhost')."""
+        trusted("localhost")
+        request = _request("localhost", {"X-Forwarded-For": "203.0.113.9"})
+        assert _get_client_ip(request) == "203.0.113.9"
+
+
+class TestLockoutAttribution:
+    """End to end: the rate limiter keys on the resolved client IP."""
+
+    @pytest.fixture
+    def fresh_limiter(self, monkeypatch):
+        limiter = LoginRateLimiter(max_attempts=5, lockout_minutes=15)
+        monkeypatch.setattr(routes, "_login_rate_limiter", limiter)
+        return limiter
+
+    async def _fail_login(self, app_client, xff: str | None = None):
+        headers = {"X-Forwarded-For": xff} if xff else {}
+        response = await app_client.post(
+            "/admin/login",
+            data={"email": "admin@example.com", "password": "wrong-password"},
+            headers=headers,
+            follow_redirects=False,
+        )
+        assert response.status_code == 200
+        return response
+
+    async def test_untrusted_xff_cannot_dodge_lockout(
+        self, app_client, admin_account, fresh_limiter, trusted
+    ):
+        """Attacker rotating XFF values behind NO trusted proxy still shares
+        one bucket (the direct peer) and gets locked out."""
+        trusted("")  # no trusted proxies at all
+        for i in range(5):
+            await self._fail_login(app_client, xff=f"203.0.113.{i}")
+        response = await app_client.post(
+            "/admin/login",
+            data={"email": admin_account["email"], "password": admin_account["password"]},
+            follow_redirects=False,
+        )
+        assert response.status_code == 200
+        assert "Too many failed attempts" in response.text
+
+    async def test_trusted_proxy_separates_clients(
+        self, app_client, admin_account, fresh_limiter, trusted, monkeypatch
+    ):
+        """The lockout DoS fix: an attacker's 5 failures no longer lock out
+        the real admin arriving from a different IP via the same proxy."""
+        # The litestar test transport reports a fixed peer ("testclient");
+        # trust it so XFF is honoured, exactly like a real reverse proxy peer.
+        trusted("127.0.0.1,::1,testclient")
+
+        for _ in range(5):
+            await self._fail_login(app_client, xff="6.6.6.6")
+
+        # Attacker's IP is locked out...
+        locked = await app_client.post(
+            "/admin/login",
+            data={"email": admin_account["email"], "password": admin_account["password"]},
+            headers={"X-Forwarded-For": "6.6.6.6"},
+            follow_redirects=False,
+        )
+        assert "Too many failed attempts" in locked.text
+
+        # ...but the admin from a different client IP logs in fine
+        response = await app_client.post(
+            "/admin/login",
+            data={"email": admin_account["email"], "password": admin_account["password"]},
+            headers={"X-Forwarded-For": "198.51.100.7"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 303


### PR DESCRIPTION
Closes #51. **Stacked on #94** — merge that first; this includes its commits until rebased.

## Problems (two, not one)
1. **Lockout DoS (the issue):** `_get_client_ip` only trusted proxy headers from localhost. In the shipped Docker deployment the reverse proxy is another container, so the peer is a Docker network IP — headers ignored, every client collapses to one shared bucket, and anyone's 5 failed logins lock the real admin out.
2. **Spoofing (found while fixing):** when headers WERE trusted, the code took the **leftmost** X-Forwarded-For entry — which the client controls, since proxies append. An attacker could dodge the limiter entirely (rotate fake XFF) or lock out a chosen victim IP.

## Changes
- New `TRUSTED_PROXIES` setting: comma-separated IPs/CIDRs (or literal peer names). Default `127.0.0.1,::1` — same trust as before.
- XFF is walked **right-to-left skipping trusted proxies**; the first untrusted hop is the client (standard algorithm). Leftmost is never believed.
- `X-Real-IP` honoured only from trusted peers.
- `.env.example` documents the setting, including `docker network inspect | grep Subnet` to find the right CIDR.

## Testing (14 new, full suite 110 passed)
- 12 unit tests on `_get_client_ip`: spoofed XFF from untrusted peer ignored, client-prepended junk not believed, Docker CIDR case, chained proxies, all-hops-trusted, X-Real-IP both directions, IPv6, invalid config entry non-fatal, literal hostname entries.
- 2 end-to-end tests through the real app + real `LoginRateLimiter`:
  - attacker rotating XFF behind no trusted proxy still shares one bucket → locked out
  - **the DoS fix itself**: attacker's 5 failures via trusted proxy lock out only `6.6.6.6`; the admin from a different IP through the same proxy logs straight in.