### PR TITLE
fix: first-run setup requires a token from the server log

### DIFF
--- a/src/polar_flow_server/admin/routes.py
+++ b/src/polar_flow_server/admin/routes.py
@@ -37,6 +37,7 @@ from polar_flow_server.core.api_keys import (
 )
 from polar_flow_server.core.config import settings
 from polar_flow_server.core.security import token_encryption
+from polar_flow_server.core.setup_token import announce_setup_token, verify_setup_token
 from polar_flow_server.models.activity import Activity
 from polar_flow_server.models.activity_samples import ActivitySamples
 from polar_flow_server.models.api_key import APIKey
@@ -202,6 +203,9 @@ class LoginRateLimiter:
 
 # Global rate limiter instance
 _login_rate_limiter = LoginRateLimiter(max_attempts=5, lockout_minutes=15)
+
+# Serializes first-run admin creation (see setup_account_submit)
+_setup_lock = asyncio.Lock()
 
 # Simple email validation pattern
 _EMAIL_PATTERN = re.compile(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
@@ -399,6 +403,10 @@ async def setup_account_form(
     if await admin_user_exists(session):
         return Redirect(path="/admin", status_code=HTTP_303_SEE_OTHER)
 
+    # (Re-)print the token so `docker logs` right after loading this page
+    # always shows it — visitors only see the form, never the token.
+    announce_setup_token()
+
     return Template(
         template_name="admin/setup_account.html",
         context={"csrf_token": _get_csrf_token(request)},
@@ -411,7 +419,9 @@ async def setup_account_submit(
 ) -> Template | Redirect:
     """Create the first admin account.
 
-    Only accessible if no admin user exists yet.
+    Only accessible if no admin user exists yet, and only with the setup
+    token from the server log — otherwise the first visitor to reach an
+    exposed instance could claim it.
     """
     if await admin_user_exists(session):
         return Redirect(path="/admin", status_code=HTTP_303_SEE_OTHER)
@@ -421,9 +431,13 @@ async def setup_account_submit(
     password = form_data.get("password", "")
     password_confirm = form_data.get("password_confirm", "")
     name = form_data.get("name", "").strip() or None
+    setup_token = str(form_data.get("setup_token", ""))
 
     # Validation
     errors = []
+    if not verify_setup_token(setup_token):
+        errors.append("Invalid setup token — check the server logs for the current one")
+
     if not email:
         errors.append("Email is required")
     elif not _EMAIL_PATTERN.match(email):
@@ -448,14 +462,18 @@ async def setup_account_submit(
             },
         )
 
-    # Create admin user
+    # Create admin user. Serialize check+create so two concurrent submits
+    # can't both pass the exists-check and create two admins.
     try:
-        admin = await create_admin_user(
-            email=str(email),
-            password=str(password),
-            session=session,
-            name=str(name) if name else None,
-        )
+        async with _setup_lock:
+            if await admin_user_exists(session):
+                return Redirect(path="/admin", status_code=HTTP_303_SEE_OTHER)
+            admin = await create_admin_user(
+                email=str(email),
+                password=str(password),
+                session=session,
+                name=str(name) if name else None,
+            )
         # Log them in immediately
         login_admin(request, admin)
         return Redirect(path="/admin", status_code=HTTP_303_SEE_OTHER)

--- a/src/polar_flow_server/app.py
+++ b/src/polar_flow_server/app.py
@@ -17,6 +17,7 @@ from litestar.template.config import TemplateConfig
 
 from polar_flow_server import __version__
 from polar_flow_server.admin import admin_router
+from polar_flow_server.admin.auth import admin_user_exists
 from polar_flow_server.api import api_routers
 from polar_flow_server.core.config import settings
 from polar_flow_server.core.database import (
@@ -26,6 +27,7 @@ from polar_flow_server.core.database import (
     init_database,
 )
 from polar_flow_server.core.security import verify_stored_tokens_decryptable
+from polar_flow_server.core.setup_token import announce_setup_token
 from polar_flow_server.middleware import RateLimitHeadersMiddleware
 from polar_flow_server.routes import root_redirect
 from polar_flow_server.services.scheduler import SyncScheduler, set_scheduler
@@ -79,6 +81,15 @@ async def lifespan(app: Litestar) -> AsyncIterator[None]:
     except Exception as exc:  # pragma: no cover - never block startup on the check
         logger.warning("Token decryptability check failed to run", error=str(exc))
 
+    # First run: print the setup token so only the operator (who can read
+    # the logs) can create the admin account.
+    try:
+        async with async_session_maker() as check_session:
+            if not await admin_user_exists(check_session):
+                announce_setup_token()
+    except Exception as exc:  # pragma: no cover - never block startup on this
+        logger.warning("Could not check for existing admin user", error=str(exc))
+
     # Start background sync scheduler
     scheduler = SyncScheduler(async_session_maker)
     set_scheduler(scheduler)
@@ -128,9 +139,11 @@ def create_app() -> Litestar:
         header_name="X-CSRF-Token",
         cookie_httponly=False,  # JS needs to read this cookie to send in header
         exclude=[
-            # Entry points (no session yet)
+            # Entry points (no session yet). Note: setup/account is protected
+            # by the one-time setup token instead; /admin/setup/oauth is NOT
+            # excluded — it runs logged-in and the form sends the CSRF token.
             "/admin/login",
-            "/admin/setup",
+            "/admin/setup/account",
             # External OAuth callbacks (redirects from Polar)
             "/admin/oauth/callback",
             "/oauth/",  # SaaS OAuth flow (callback, exchange, start)

--- a/src/polar_flow_server/core/setup_token.py
+++ b/src/polar_flow_server/core/setup_token.py
@@ -1,0 +1,56 @@
+"""One-time first-run setup token (issue #52).
+
+Until an admin account exists, /admin/setup/account is necessarily open —
+whoever reaches it first owns the instance. To make sure that's the operator
+and not a drive-by visitor, account creation requires a token that is only
+ever printed to the server log (the Jellyfin/Grafana pattern).
+
+The token lives in process memory: one per server run, generated lazily,
+gone once setup completes or the process restarts.
+"""
+
+import logging
+import secrets
+
+logger = logging.getLogger(__name__)
+
+_token: str | None = None
+
+
+def get_setup_token() -> str:
+    """Return this run's setup token, generating it on first use."""
+    global _token
+    if _token is None:
+        _token = secrets.token_urlsafe(24)
+    return _token
+
+
+def verify_setup_token(submitted: str) -> bool:
+    """Constant-time comparison against the current setup token."""
+    return secrets.compare_digest(submitted.strip(), get_setup_token())
+
+
+def announce_setup_token() -> None:
+    """Print the setup token to the server log, loudly."""
+    token = get_setup_token()
+    logger.warning(
+        "\n"
+        "============================================================\n"
+        "  FIRST-RUN SETUP\n"
+        "  No admin account exists yet. To create one, open /admin\n"
+        "  and enter this setup token when asked:\n"
+        "\n"
+        "      %s\n"
+        "\n"
+        "  (Anyone who can reach this server before setup completes\n"
+        "  could otherwise claim it. The token proves you're the\n"
+        "  operator: only you can read this log.)\n"
+        "============================================================",
+        token,
+    )
+
+
+def reset_setup_token_for_tests() -> None:
+    """Test hook: forget the current token so a fresh one is generated."""
+    global _token
+    _token = None

--- a/src/polar_flow_server/templates/admin/setup_account.html
+++ b/src/polar_flow_server/templates/admin/setup_account.html
@@ -23,6 +23,24 @@
         <form method="POST" action="/admin/setup/account" class="space-y-6">
             {% if csrf_token %}<input type="hidden" name="_csrf_token" value="{{ csrf_token }}">{% endif %}
             <div>
+                <label for="setup_token" class="block text-sm font-medium text-gray-700 mb-1">
+                    Setup token <span class="text-red-500">*</span>
+                </label>
+                <input
+                    type="text"
+                    id="setup_token"
+                    name="setup_token"
+                    required
+                    autocomplete="off"
+                    class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 font-mono"
+                    placeholder="Paste the token from the server logs"
+                >
+                <p class="mt-1 text-xs text-gray-500">
+                    Printed in the server logs at startup (e.g. <code class="font-mono">docker compose logs polar-flow-server</code>).
+                    It proves you're the operator of this server.
+                </p>
+            </div>
+            <div>
                 <label for="name" class="block text-sm font-medium text-gray-700 mb-1">
                     Name (optional)
                 </label>

--- a/tests/test_setup_token.py
+++ b/tests/test_setup_token.py
@@ -1,0 +1,151 @@
+"""First-run setup token tests (issue #52).
+
+Proves the instance can no longer be claimed by whoever visits first: admin
+creation requires the token from the server log, and concurrent submits
+cannot create two admins.
+"""
+
+import asyncio
+import logging
+
+import pytest
+from sqlalchemy import func, select
+
+from polar_flow_server.core import setup_token as setup_token_module
+from polar_flow_server.core.setup_token import (
+    announce_setup_token,
+    get_setup_token,
+    reset_setup_token_for_tests,
+    verify_setup_token,
+)
+
+VALID_FORM = {
+    "email": "owner@example.com",
+    "password": "a-strong-password",
+    "password_confirm": "a-strong-password",
+    "name": "Owner",
+}
+
+
+@pytest.fixture(autouse=True)
+def fresh_token():
+    reset_setup_token_for_tests()
+    yield
+    reset_setup_token_for_tests()
+
+
+async def _admin_count() -> int:
+    from polar_flow_server.core.database import async_session_maker
+    from polar_flow_server.models.admin_user import AdminUser
+
+    async with async_session_maker() as session:
+        result = await session.execute(select(func.count(AdminUser.id)))
+        return result.scalar() or 0
+
+
+class TestTokenPrimitive:
+    def test_token_is_stable_within_run(self):
+        assert get_setup_token() == get_setup_token()
+
+    def test_verify(self):
+        assert verify_setup_token(get_setup_token())
+        assert verify_setup_token("  " + get_setup_token() + " ")  # forgiving paste
+        assert not verify_setup_token("nope")
+        assert not verify_setup_token("")
+
+    def test_announce_logs_the_token(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="polar_flow_server.core.setup_token"):
+            announce_setup_token()
+        assert get_setup_token() in caplog.text
+        assert "FIRST-RUN SETUP" in caplog.text
+
+
+class TestSetupFlow:
+    async def test_setup_page_loads_and_announces_token(self, app_client, caplog):
+        with caplog.at_level(logging.WARNING, logger="polar_flow_server.core.setup_token"):
+            response = await app_client.get("/admin/setup/account")
+        assert response.status_code == 200
+        assert get_setup_token() in caplog.text
+        # The token must never be IN the page itself
+        assert get_setup_token() not in response.text
+
+    async def test_submit_without_token_is_rejected(self, app_client):
+        response = await app_client.post(
+            "/admin/setup/account", data=VALID_FORM, follow_redirects=False
+        )
+        assert response.status_code == 200
+        assert "Invalid setup token" in response.text
+        assert await _admin_count() == 0
+
+    async def test_submit_with_wrong_token_is_rejected(self, app_client):
+        response = await app_client.post(
+            "/admin/setup/account",
+            data={**VALID_FORM, "setup_token": "guessed-wrong"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 200
+        assert "Invalid setup token" in response.text
+        assert await _admin_count() == 0
+
+    async def test_submit_with_token_creates_admin_and_logs_in(self, app_client):
+        response = await app_client.post(
+            "/admin/setup/account",
+            data={**VALID_FORM, "setup_token": get_setup_token()},
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+        assert response.headers["location"] == "/admin"
+        assert await _admin_count() == 1
+
+        # Setup is now closed: the form redirects away...
+        page = await app_client.get("/admin/setup/account", follow_redirects=False)
+        assert page.status_code == 303
+        # ...and replaying the token creates nothing
+        replay = await app_client.post(
+            "/admin/setup/account",
+            data={**VALID_FORM, "email": "second@example.com", "setup_token": get_setup_token()},
+            follow_redirects=False,
+        )
+        assert replay.status_code == 303
+        assert await _admin_count() == 1
+
+    async def test_concurrent_submits_create_exactly_one_admin(self, app_client):
+        """Two racing submits with distinct emails must not both create."""
+        token = get_setup_token()
+
+        async def submit(email: str):
+            return await app_client.post(
+                "/admin/setup/account",
+                data={**VALID_FORM, "email": email, "setup_token": token},
+                follow_redirects=False,
+            )
+
+        results = await asyncio.gather(
+            submit("first@example.com"), submit("second@example.com")
+        )
+        assert {r.status_code for r in results} == {303}
+        assert await _admin_count() == 1
+
+    async def test_login_and_dashboard_still_work_after_token_setup(self, app_client):
+        """Full first-run journey: setup -> logout -> login."""
+        await app_client.post(
+            "/admin/setup/account",
+            data={**VALID_FORM, "setup_token": get_setup_token()},
+            follow_redirects=False,
+        )
+        # Fresh session
+        app_client.cookies.clear()
+        response = await app_client.post(
+            "/admin/login",
+            data={"email": VALID_FORM["email"], "password": VALID_FORM["password"]},
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+
+
+class TestModuleState:
+    def test_reset_generates_new_token(self):
+        first = get_setup_token()
+        reset_setup_token_for_tests()
+        assert get_setup_token() != first
+        assert setup_token_module._token is not None

--- a/tests/test_setup_token.py
+++ b/tests/test_setup_token.py
@@ -120,9 +120,7 @@ class TestSetupFlow:
                 follow_redirects=False,
             )
 
-        results = await asyncio.gather(
-            submit("first@example.com"), submit("second@example.com")
-        )
+        results = await asyncio.gather(submit("first@example.com"), submit("second@example.com"))
         assert {r.status_code for r in results} == {303}
         assert await _admin_count() == 1
 


### PR DESCRIPTION
Closes #52. **Stacked on #94** — merge that first; this includes its commits until rebased.

## Problem
`/admin/setup/account` is open whenever no admin exists and logs the creator straight in. DNS live before first visit, or a redeploy with a wiped DB, and the first visitor owns the instance. Bonus race: two concurrent submits with different emails both passed `admin_user_exists` and created two admins.

## Changes
- **Setup token** (Jellyfin/Grafana pattern): a per-process token is printed to the server log at startup when no admin exists, and re-printed whenever the setup page loads — so `docker compose logs polar-flow-server` always shows a current one. The form requires it; comparison is constant-time; it never appears in any HTTP response.
- **Race closed**: check+create serialized behind an asyncio lock with a re-check (single-process deployment, same assumption the session store already makes).
- **CSRF exclusion narrowed** (the follow-up flagged in #94): `/admin/setup` → `/admin/setup/account`. `POST /admin/setup/oauth` runs logged-in and its form already sends the CSRF token both ways, so it's now protected.
- Setup form gets a token field with instructions pointing at the logs.

## Testing
10 new tests in `tests/test_setup_token.py`:
- token primitive (stable per run, constant-time verify, paste-forgiving, announce logs it)
- setup page loads + announces, **token never leaks into the page**
- submit without / with wrong token → rejected, zero admins created
- correct token → admin created + logged in; setup then closed; token replay creates nothing
- **two concurrent submits → exactly one admin**
- full journey: setup → fresh session → login works

Full suite: **106 passed** (84 baseline + 12 from #94 + 10 new). mypy clean; ruff findings are the 14 pre-existing on main, none in touched files.