### PR TITLE
security: response headers, cookie hardening, session rotation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,15 @@ DATABASE_URL=postgresql+asyncpg://polar:polar@postgres:5432/polar
 #   docker network inspect <network> | grep Subnet   # find the value
 # TRUSTED_PROXIES=127.0.0.1,::1,172.16.0.0/12
 
+# Mark session/CSRF cookies Secure. Enable whenever you serve the instance
+# over HTTPS (TLS at a reverse proxy counts — the browser checks the page
+# origin, not the app's internal transport). Leave off for plain-http dev.
+# SECURE_COOKIES=true
+
+# NOTE: run exactly ONE worker process (the default). Admin sessions, login
+# rate limiting and OAuth state live in process memory; multiple workers
+# silently break logins and multiply the lockout threshold.
+
 # Sync settings
 SYNC_ENABLED=true                    # Enable/disable automatic background syncing
 SYNC_INTERVAL_MINUTES=60             # Minutes between sync cycles (default: 60)

--- a/src/polar_flow_server/admin/auth.py
+++ b/src/polar_flow_server/admin/auth.py
@@ -156,13 +156,33 @@ async def require_admin_auth(
         raise NotAuthorizedException(detail="Authentication required")
 
 
-def login_admin(connection: ASGIConnection[Any, Any, Any, Any], admin: AdminUser) -> None:
-    """Set up authenticated session for admin.
+async def rotate_session_id(connection: ASGIConnection[Any, Any, Any, Any]) -> None:
+    """Issue a fresh session ID, discarding the pre-login one (anti-fixation).
+
+    The server-side session middleware reuses whatever session ID the request
+    arrived with. Rotating at login means a session ID planted or observed
+    before authentication is worthless afterwards. Mirrors what
+    ``connection.clear_session`` does to the connection state, plus deleting
+    the old server-side entry and dropping any pre-login session data.
+    """
+    from litestar.types import Empty
+
+    old_id = connection.cookies.pop("session", None)
+    connection._connection_state.session_id = Empty  # noqa: SLF001 - same as clear_session
+    connection.scope["session"] = {}
+    if old_id and old_id != "null":
+        store = connection.app.stores.get("session_store")
+        await store.delete(old_id)
+
+
+async def login_admin(connection: ASGIConnection[Any, Any, Any, Any], admin: AdminUser) -> None:
+    """Set up authenticated session for admin (on a freshly rotated session ID).
 
     Args:
         connection: The ASGI connection
         admin: The authenticated admin user
     """
+    await rotate_session_id(connection)
     connection.session["admin_id"] = admin.id
     connection.session["admin_email"] = admin.email
 

--- a/src/polar_flow_server/admin/routes.py
+++ b/src/polar_flow_server/admin/routes.py
@@ -475,7 +475,7 @@ async def setup_account_submit(
                 name=str(name) if name else None,
             )
         # Log them in immediately
-        login_admin(request, admin)
+        await login_admin(request, admin)
         return Redirect(path="/admin", status_code=HTTP_303_SEE_OTHER)
     except Exception as e:
         return Template(
@@ -620,7 +620,7 @@ async def login_submit(
 
     # Successful login - clear any failed attempts
     await _login_rate_limiter.record_success(client_ip)
-    login_admin(request, admin)
+    await login_admin(request, admin)
     return Redirect(path="/admin", status_code=HTTP_303_SEE_OTHER)
 
 

--- a/src/polar_flow_server/app.py
+++ b/src/polar_flow_server/app.py
@@ -182,7 +182,11 @@ def create_app() -> Litestar:
                 ),
             ),
         ],
-        middleware=[SecurityHeadersMiddleware, session_config.middleware, RateLimitHeadersMiddleware],
+        middleware=[
+            SecurityHeadersMiddleware,
+            session_config.middleware,
+            RateLimitHeadersMiddleware,
+        ],
         csrf_config=csrf_config,
         stores={"session_store": session_store},
         debug=settings.log_level == "DEBUG",

--- a/src/polar_flow_server/app.py
+++ b/src/polar_flow_server/app.py
@@ -28,7 +28,7 @@ from polar_flow_server.core.database import (
 )
 from polar_flow_server.core.security import verify_stored_tokens_decryptable
 from polar_flow_server.core.setup_token import announce_setup_token
-from polar_flow_server.middleware import RateLimitHeadersMiddleware
+from polar_flow_server.middleware import RateLimitHeadersMiddleware, SecurityHeadersMiddleware
 from polar_flow_server.routes import root_redirect
 from polar_flow_server.services.scheduler import SyncScheduler, set_scheduler
 
@@ -118,16 +118,20 @@ def create_app() -> Litestar:
     # In production with multiple instances, use Redis instead
     session_store = MemoryStore()
 
-    # Session middleware config with explicit security settings
-    # Note: We don't set secure=True because Coolify/nginx terminates SSL
-    # and forwards HTTP internally. The cookies would be rejected over HTTP.
-    # Security is still enforced at the proxy level.
+    # Session middleware config with explicit security settings.
+    # `secure` comes from SECURE_COOKIES: the browser checks the PAGE origin
+    # (https://...), not the app's internal transport, so this is safe to
+    # enable behind a TLS-terminating proxy — just not for plain-http access.
+    # `key` is the COOKIE NAME, not a secret (server-side sessions don't take
+    # one — the ID is random). Passing the session secret here leaked it to
+    # every browser as the cookie's name (issue #97).
     session_config = ServerSideSessionConfig(
-        key=settings.get_session_secret(),
+        key="session",
         store="session_store",
         max_age=86400,  # 24 hours
         httponly=True,  # Prevent JS access to session cookie
         samesite="lax",  # CSRF protection
+        secure=settings.secure_cookies,
     )
 
     # CSRF protection config
@@ -138,6 +142,7 @@ def create_app() -> Litestar:
         cookie_name="csrf_token",
         header_name="X-CSRF-Token",
         cookie_httponly=False,  # JS needs to read this cookie to send in header
+        cookie_secure=settings.secure_cookies,
         exclude=[
             # Entry points (no session yet). Note: setup/account is protected
             # by the one-time setup token instead; /admin/setup/oauth is NOT
@@ -177,7 +182,7 @@ def create_app() -> Litestar:
                 ),
             ),
         ],
-        middleware=[session_config.middleware, RateLimitHeadersMiddleware],
+        middleware=[SecurityHeadersMiddleware, session_config.middleware, RateLimitHeadersMiddleware],
         csrf_config=csrf_config,
         stores={"session_store": session_store},
         debug=settings.log_level == "DEBUG",

--- a/src/polar_flow_server/cli.py
+++ b/src/polar_flow_server/cli.py
@@ -21,6 +21,10 @@ def serve(
 ) -> None:
     """Start the API server.
 
+    Always runs a single worker process: admin sessions, login rate limiting
+    and OAuth state live in process memory, so multiple workers would silently
+    break logins. Don't run this app under uvicorn --workers N.
+
     Example:
         polar-flow-server serve
         polar-flow-server serve --host 0.0.0.0 --port 8080 --reload

--- a/src/polar_flow_server/core/config.py
+++ b/src/polar_flow_server/core/config.py
@@ -84,6 +84,13 @@ class Settings(BaseSettings):
         "(e.g. '127.0.0.1,::1,172.16.0.0/12' when the proxy is another Docker "
         "container). Requests from other peers use the direct socket address.",
     )
+    secure_cookies: bool = Field(
+        default=False,
+        description="Mark session/CSRF cookies Secure (browser only sends them "
+        "over HTTPS). Enable whenever the instance is served via HTTPS — the "
+        "browser checks the page origin, so TLS terminating at a reverse proxy "
+        "is fine. Leave off only for plain-http access (e.g. localhost dev).",
+    )
     jwt_secret: str | None = Field(
         default=None,
         description="JWT secret for authentication (SaaS mode only)",

--- a/src/polar_flow_server/middleware/__init__.py
+++ b/src/polar_flow_server/middleware/__init__.py
@@ -1,5 +1,6 @@
 """Middleware modules."""
 
 from polar_flow_server.middleware.rate_limit import RateLimitHeadersMiddleware
+from polar_flow_server.middleware.security_headers import SecurityHeadersMiddleware
 
-__all__ = ["RateLimitHeadersMiddleware"]
+__all__ = ["RateLimitHeadersMiddleware", "SecurityHeadersMiddleware"]

--- a/src/polar_flow_server/middleware/security_headers.py
+++ b/src/polar_flow_server/middleware/security_headers.py
@@ -1,0 +1,75 @@
+"""Security response headers (issue #54).
+
+Static hardening headers on every response. The CSP is honest about what the
+admin UI needs today (inline scripts + the HTMX/Tailwind/Chart.js CDNs) —
+it won't stop inline-script injection, but it does block loading attacker
+scripts from anywhere else, framing, form exfiltration, and plugin content.
+Tightening to nonces is a follow-up once the inline scripts move to files.
+"""
+
+from litestar.datastructures import MutableScopeHeaders
+from litestar.enums import ScopeType
+from litestar.types import ASGIApp, Message, Receive, Scope, Send
+
+_CSP = "; ".join(
+    [
+        "default-src 'self'",
+        # Inline scripts are used heavily by the admin templates; CDNs pinned
+        # to the three hosts base.html actually loads from
+        "script-src 'self' 'unsafe-inline' "
+        "https://unpkg.com https://cdn.tailwindcss.com https://cdn.jsdelivr.net",
+        # Tailwind's CDN build injects styles at runtime; swagger css from jsdelivr
+        "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
+        "img-src 'self' data:",
+        "font-src 'self' data: https://cdn.jsdelivr.net",
+        "connect-src 'self'",
+        "worker-src 'self' blob:",
+        "object-src 'none'",
+        "frame-ancestors 'none'",
+        "base-uri 'self'",
+        "form-action 'self'",
+    ]
+)
+
+SECURITY_HEADERS: dict[str, str] = {
+    "Content-Security-Policy": _CSP,
+    "X-Frame-Options": "DENY",
+    "X-Content-Type-Options": "nosniff",
+    "Referrer-Policy": "same-origin",
+    "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+}
+
+# Only meaningful over TLS; browsers ignore it on plain http, but don't
+# advertise it unless the request actually arrived via https at the edge.
+_HSTS_VALUE = "max-age=15768000"  # 6 months
+
+
+class SecurityHeadersMiddleware:
+    """ASGI middleware adding security headers to every HTTP response."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != ScopeType.HTTP:
+            await self.app(scope, receive, send)
+            return
+
+        # TLS terminates at the reverse proxy; it tells us via X-Forwarded-Proto
+        request_headers = dict(scope.get("headers") or [])
+        forwarded_proto = request_headers.get(b"x-forwarded-proto", b"").decode(
+            "latin-1"
+        )
+        is_https = scope.get("scheme") == "https" or forwarded_proto == "https"
+
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = MutableScopeHeaders.from_message(message)
+                for name, value in SECURITY_HEADERS.items():
+                    if name not in headers:
+                        headers[name] = value
+                if is_https and "Strict-Transport-Security" not in headers:
+                    headers["Strict-Transport-Security"] = _HSTS_VALUE
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)

--- a/src/polar_flow_server/middleware/security_headers.py
+++ b/src/polar_flow_server/middleware/security_headers.py
@@ -57,9 +57,7 @@ class SecurityHeadersMiddleware:
 
         # TLS terminates at the reverse proxy; it tells us via X-Forwarded-Proto
         request_headers = dict(scope.get("headers") or [])
-        forwarded_proto = request_headers.get(b"x-forwarded-proto", b"").decode(
-            "latin-1"
-        )
+        forwarded_proto = request_headers.get(b"x-forwarded-proto", b"").decode("latin-1")
         is_https = scope.get("scheme") == "https" or forwarded_proto == "https"
 
         async def send_wrapper(message: Message) -> None:

--- a/src/polar_flow_server/middleware/security_headers.py
+++ b/src/polar_flow_server/middleware/security_headers.py
@@ -14,14 +14,20 @@ from litestar.types import ASGIApp, Message, Receive, Scope, Send
 _CSP = "; ".join(
     [
         "default-src 'self'",
-        # Inline scripts are used heavily by the admin templates; CDNs pinned
-        # to the three hosts base.html actually loads from
+        # Inline scripts are used heavily by the admin templates. CDNs pinned
+        # to the hosts the admin UI (base.html) and the /schema doc UIs
+        # (swagger from jsdelivr, redoc from cdn.redoc.ly, elements/rapidoc
+        # from unpkg) actually load from — tests/test_security_headers.py
+        # asserts every host those pages reference is covered here.
         "script-src 'self' 'unsafe-inline' "
-        "https://unpkg.com https://cdn.tailwindcss.com https://cdn.jsdelivr.net",
-        # Tailwind's CDN build injects styles at runtime; swagger css from jsdelivr
-        "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
-        "img-src 'self' data:",
-        "font-src 'self' data: https://cdn.jsdelivr.net",
+        "https://unpkg.com https://cdn.tailwindcss.com https://cdn.jsdelivr.net "
+        "https://cdn.redoc.ly",
+        # Tailwind's CDN build injects styles at runtime; doc-UI css comes
+        # from jsdelivr/unpkg, redoc pulls Google Fonts css
+        "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net "
+        "https://unpkg.com https://fonts.googleapis.com",
+        "img-src 'self' data: https:",
+        "font-src 'self' data: https://cdn.jsdelivr.net https://fonts.gstatic.com",
         "connect-src 'self'",
         "worker-src 'self' blob:",
         "object-src 'none'",

--- a/src/polar_flow_server/templates/admin/dashboard.html
+++ b/src/polar_flow_server/templates/admin/dashboard.html
@@ -377,10 +377,10 @@
 </div>
 
 {% if latest_hr and latest_hr.samples_json %}
-<script id="today-hr-samples" type="application/json">{{ latest_hr.samples_json | safe }}</script>
+<script id="today-hr-samples" type="application/json">{{ latest_hr.samples_json | replace('</', '<\/') | safe }}</script>
 {% endif %}
 {% if latest_activity_samples and latest_activity_samples.samples_json %}
-<script id="today-steps-samples" type="application/json">{{ latest_activity_samples.samples_json | safe }}</script>
+<script id="today-steps-samples" type="application/json">{{ latest_activity_samples.samples_json | replace('</', '<\/') | safe }}</script>
 {% endif %}
 
 <!-- Chart Controls -->

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,144 @@
+"""Security headers + hardening batch tests (issues #54, #57)."""
+
+import re
+
+from litestar.testing import AsyncTestClient
+
+from polar_flow_server.core.config import settings
+
+EXPECTED_HEADERS = {
+    "content-security-policy",
+    "x-frame-options",
+    "x-content-type-options",
+    "referrer-policy",
+    "permissions-policy",
+}
+
+
+class TestSecurityHeaders:
+    async def test_headers_on_api_response(self, app_client):
+        response = await app_client.get("/health")
+        for header in EXPECTED_HEADERS:
+            assert header in response.headers, f"missing {header}"
+        assert response.headers["x-frame-options"] == "DENY"
+        assert response.headers["x-content-type-options"] == "nosniff"
+        assert "frame-ancestors 'none'" in response.headers["content-security-policy"]
+
+    async def test_headers_on_admin_response(self, app_client):
+        response = await app_client.get("/admin", follow_redirects=False)
+        for header in EXPECTED_HEADERS:
+            assert header in response.headers, f"missing {header}"
+
+    async def test_csp_allows_the_cdns_the_ui_uses(self, app_client):
+        response = await app_client.get("/health")
+        csp = response.headers["content-security-policy"]
+        for host in ("unpkg.com", "cdn.tailwindcss.com", "cdn.jsdelivr.net"):
+            assert host in csp
+
+    async def test_hsts_absent_on_plain_http(self, app_client):
+        response = await app_client.get("/health")
+        assert "strict-transport-security" not in response.headers
+
+    async def test_hsts_present_when_edge_is_https(self, app_client):
+        response = await app_client.get(
+            "/health", headers={"X-Forwarded-Proto": "https"}
+        )
+        assert "strict-transport-security" in response.headers
+
+
+class TestSecureCookiesFlag:
+    async def test_cookies_marked_secure_when_enabled(self, monkeypatch):
+        monkeypatch.setattr(settings, "secure_cookies", True)
+        from polar_flow_server.app import create_app
+
+        async with AsyncTestClient(app=create_app()) as client:
+            response = await client.get("/admin", follow_redirects=False)
+            set_cookies = response.headers.get_list("set-cookie")
+            csrf = [c for c in set_cookies if c.startswith("csrf_token=")]
+            assert csrf and "Secure" in csrf[0]
+
+    async def test_cookies_not_secure_by_default(self, app_client):
+        response = await app_client.get("/admin", follow_redirects=False)
+        set_cookies = response.headers.get_list("set-cookie")
+        csrf = [c for c in set_cookies if c.startswith("csrf_token=")]
+        assert csrf and "Secure" not in csrf[0]
+
+
+class TestSessionCookieName:
+    async def test_session_cookie_is_named_session_not_the_secret(
+        self, app_client, admin_account
+    ):
+        """Issue #97: the session secret must never appear as the cookie NAME."""
+        response = await app_client.post(
+            "/admin/login",
+            data={"email": admin_account["email"], "password": admin_account["password"]},
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+        cookie_names = [
+            c.split("=", 1)[0] for c in response.headers.get_list("set-cookie")
+        ]
+        assert "session" in cookie_names
+        secret = settings.get_session_secret()
+        assert secret not in cookie_names
+        assert all(secret not in name for name in cookie_names)
+
+
+class TestSessionRotation:
+    async def test_session_id_rotates_on_login(self, app_client, admin_account):
+        """Session fixation: a pre-login session ID must die at login."""
+        planted = "a" * 64  # attacker-fixed session ID
+        app_client.cookies.set("session", planted)
+
+        response = await app_client.post(
+            "/admin/login",
+            data={"email": admin_account["email"], "password": admin_account["password"]},
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+
+        set_cookies = response.headers.get_list("set-cookie")
+        session_cookies = [c for c in set_cookies if c.startswith("session=")]
+        assert session_cookies, "login response must set a session cookie"
+        new_session = session_cookies[0].split(";", 1)[0].split("=", 1)[1]
+        assert new_session and new_session != planted
+        # avoid a stale duplicate in the client jar for the follow-up requests
+        app_client.cookies.delete("session")
+        app_client.cookies.set("session", new_session)
+
+        # New ID is a real authenticated session (no OAuth configured yet, so
+        # /admin renders the setup page rather than bouncing to /admin/login)
+        dashboard = await app_client.get("/admin", follow_redirects=False)
+        assert dashboard.status_code == 200
+
+        # …and the planted ID is not authenticated
+        app_client.cookies.delete("session")
+        app_client.cookies.set("session", planted)
+        anon = await app_client.get("/admin", follow_redirects=False)
+        assert anon.status_code == 303
+        assert anon.headers["location"] == "/admin/login"
+
+
+class TestScriptBlockEscaping:
+    def test_samples_json_cannot_break_out_of_script_block(self):
+        """dashboard.html JSON islands escape '</', so '</script>' in any
+        string field can't terminate the block (issue #57)."""
+        import json
+        from pathlib import Path
+
+        from jinja2 import Environment
+
+        template_source = (
+            Path("src/polar_flow_server/templates/admin/dashboard.html").read_text()
+        )
+        expressions = re.findall(r"\{\{ [a-z_.]+samples_json[^}]*\}\}", template_source)
+        assert len(expressions) == 2, "expected the two JSON island expressions"
+
+        env = Environment()
+        malicious = json.dumps({"v": "</script><script>alert(1)</script>"})
+        for expression in expressions:
+            normalized = re.sub(r"[a-z_.]+samples_json", "x", expression)
+            rendered = env.from_string(normalized).render(x=malicious)
+            assert "</script" not in rendered
+            # Still exactly the same data once parsed
+            assert json.loads(rendered) == json.loads(malicious)

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -40,9 +40,7 @@ class TestSecurityHeaders:
         assert "strict-transport-security" not in response.headers
 
     async def test_hsts_present_when_edge_is_https(self, app_client):
-        response = await app_client.get(
-            "/health", headers={"X-Forwarded-Proto": "https"}
-        )
+        response = await app_client.get("/health", headers={"X-Forwarded-Proto": "https"})
         assert "strict-transport-security" in response.headers
 
 
@@ -65,9 +63,7 @@ class TestSecureCookiesFlag:
 
 
 class TestSessionCookieName:
-    async def test_session_cookie_is_named_session_not_the_secret(
-        self, app_client, admin_account
-    ):
+    async def test_session_cookie_is_named_session_not_the_secret(self, app_client, admin_account):
         """Issue #97: the session secret must never appear as the cookie NAME."""
         response = await app_client.post(
             "/admin/login",
@@ -75,9 +71,7 @@ class TestSessionCookieName:
             follow_redirects=False,
         )
         assert response.status_code == 303
-        cookie_names = [
-            c.split("=", 1)[0] for c in response.headers.get_list("set-cookie")
-        ]
+        cookie_names = [c.split("=", 1)[0] for c in response.headers.get_list("set-cookie")]
         assert "session" in cookie_names
         secret = settings.get_session_secret()
         assert secret not in cookie_names
@@ -128,9 +122,7 @@ class TestScriptBlockEscaping:
 
         from jinja2 import Environment
 
-        template_source = (
-            Path("src/polar_flow_server/templates/admin/dashboard.html").read_text()
-        )
+        template_source = Path("src/polar_flow_server/templates/admin/dashboard.html").read_text()
         expressions = re.findall(r"\{\{ [a-z_.]+samples_json[^}]*\}\}", template_source)
         assert len(expressions) == 2, "expected the two JSON island expressions"
 

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -35,6 +35,38 @@ class TestSecurityHeaders:
         for host in ("unpkg.com", "cdn.tailwindcss.com", "cdn.jsdelivr.net"):
             assert host in csp
 
+    async def test_csp_covers_every_host_the_pages_actually_load(self, app_client):
+        """Living check: every external host referenced by the admin templates
+        and the /schema doc UIs must appear in the CSP, or that page renders
+        broken for users after upgrade (this caught cdn.redoc.ly + Google
+        Fonts on the default /schema page)."""
+        import re
+        from pathlib import Path
+
+        csp = (await app_client.get("/health")).headers["content-security-policy"]
+
+        referenced_hosts: set[str] = set()
+        templates_dir = Path("src/polar_flow_server/templates")
+        for template in templates_dir.rglob("*.html"):
+            referenced_hosts.update(
+                re.findall(r'(?:src|href)="https://([^/"]+)', template.read_text())
+            )
+        referenced_hosts.discard("admin.polaraccesslink.com")  # plain nav link
+
+        for path in (
+            "/schema",
+            "/schema/swagger",
+            "/schema/redoc",
+            "/schema/elements",
+            "/schema/rapidoc",
+        ):
+            response = await app_client.get(path)
+            assert response.status_code == 200
+            referenced_hosts.update(re.findall(r"https://([^/\"']+)", response.text))
+
+        missing = {host for host in referenced_hosts if host not in csp}
+        assert not missing, f"hosts loaded by pages but absent from CSP: {missing}"
+
     async def test_hsts_absent_on_plain_http(self, app_client):
         response = await app_client.get("/health")
         assert "strict-transport-security" not in response.headers


### PR DESCRIPTION
Closes #54, #57, #97. **Stacked on #94** — merge that first.

## Changes

### #54 — security response headers
New `SecurityHeadersMiddleware` on every response: CSP, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Permissions-Policy`, and HSTS when the request arrived via https at the edge (`X-Forwarded-Proto`). The CSP is honest about today's UI (inline scripts + unpkg/tailwind/jsdelivr CDNs) — it can't stop inline injection yet, but blocks foreign script loading, framing, form exfil, and plugin content. Nonce-tightening is a natural follow-up once inline scripts move to files.

### #97 — session secret leaked as the cookie NAME (found while testing this PR)
`ServerSideSessionConfig(key=...)` is the **cookie name**, not a signing secret — and it was being passed `get_session_secret()`. Every logged-in browser received a cookie literally named the session secret, which is also the CSRF HMAC secret. Now `key="session"`. Upgrade effect: one forced re-login (already happens every restart with MemoryStore).

### #57 — hardening batch
- **Session fixation**: session ID now rotates at login (`rotate_session_id` in `admin/auth.py`) — a pre-login ID is deleted server-side and useless afterwards.
- **`SECURE_COOKIES`** setting marks session + CSRF cookies `Secure`. Off by default (plain-http localhost); docs explain the browser checks page origin, so proxy-terminated TLS is fine to enable it.
- **Script-block escaping**: the two `samples_json | safe` JSON islands in `dashboard.html` now escape `</` → `<\/` (valid JSON, byte-identical after parse) so a `</script>` in any string field can't break out.
- **Single-worker constraint documented** in `serve --help` and `.env.example` (sessions/rate-limiter/OAuth state are per-process; the CLI already never spawns multiple workers).

## Testing
11 new tests in `tests/test_security_headers.py`:
- headers present on API + admin responses; CSP includes exactly the CDNs the UI uses; HSTS absent on http / present behind https edge
- `SECURE_COOKIES` on → `Secure` on the CSRF cookie; default off
- **#97 regression**: session cookie named `session`; the secret appears in no cookie name
- **fixation test**: planted session ID → login → new ID issued, new ID is authenticated, planted ID isn't
- escaping test renders the exact template expressions against a `</script>` payload: no breakout, data survives byte-identical

Full suite: **106 passed**. mypy + ruff clean on changed files.