### PR TITLE
security: SaaS OAuth callback origins must be registered

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,11 @@ DATABASE_URL=postgresql+asyncpg://polar:polar@postgres:5432/polar
 # rate limiting and OAuth state live in process memory; multiple workers
 # silently break logins and multiply the lockout threshold.
 
+# Origins allowed as callback_url for the SaaS /oauth/start flow, comma
+# separated (scheme://host[:port]). The flow hands out single-use auth codes
+# to the callback, so it stays disabled until you register your client here.
+# OAUTH_ALLOWED_CALLBACK_ORIGINS=https://app.example.com,http://localhost:8080
+
 # Sync settings
 SYNC_ENABLED=true                    # Enable/disable automatic background syncing
 SYNC_INTERVAL_MINUTES=60             # Minutes between sync cycles (default: 60)

--- a/src/polar_flow_server/api/keys.py
+++ b/src/polar_flow_server/api/keys.py
@@ -118,8 +118,23 @@ def _is_localhost(netloc: str) -> bool:
     return host in {"localhost", "127.0.0.1", "::1", "[::1]"}
 
 
+def _allowed_callback_origins() -> set[str]:
+    """Parse OAUTH_ALLOWED_CALLBACK_ORIGINS into normalized origins."""
+    raw = settings.oauth_allowed_callback_origins or ""
+    return {
+        origin.strip().lower().rstrip("/")
+        for origin in raw.split(",")
+        if origin.strip()
+    }
+
+
 def _validate_callback_url(callback_url: str) -> tuple[bool, str]:
-    """Validate that callback_url is well-formed and secure.
+    """Validate that callback_url is well-formed, secure, and registered.
+
+    The OAuth flow delivers single-use auth codes to this URL, so on top of
+    the shape checks its origin must be on the server-side allowlist —
+    otherwise anyone who gets a user to click an /oauth/start link with an
+    attacker callback_url receives that user's code and API key.
 
     Returns (is_valid, error_message).
     """
@@ -149,6 +164,17 @@ def _validate_callback_url(callback_url: str) -> tuple[bool, str]:
         # In development, only allow http for actual localhost
         if not _is_localhost(parsed.netloc):
             return False, "HTTP only allowed for localhost in development"
+
+    # Origin must be registered by the operator
+    allowed_origins = _allowed_callback_origins()
+    if not allowed_origins:
+        return False, (
+            "No callback origins are registered on this server "
+            "(set OAUTH_ALLOWED_CALLBACK_ORIGINS)"
+        )
+    origin = f"{parsed.scheme}://{parsed.netloc}".lower()
+    if origin not in allowed_origins:
+        return False, "callback_url origin is not registered on this server"
 
     return True, ""
 
@@ -410,10 +436,12 @@ async def oauth_callback_saas(
         )
         return Redirect(path=f"{callback_url}?{success_params}", status_code=HTTP_303_SEE_OTHER)
 
-    except Exception as e:
-        logger.exception(f"SaaS OAuth callback failed: {e}")
+    except Exception:
+        logger.exception("SaaS OAuth callback failed")
         await session.rollback()
-        error_params = urlencode({"error": str(e), "status": "failed"})
+        # Generic token only — raw exception text can leak internals to the
+        # third-party callback. Details are in the server log above.
+        error_params = urlencode({"error": "server_error", "status": "failed"})
         return Redirect(path=f"{callback_url}?{error_params}", status_code=HTTP_303_SEE_OTHER)
 
 

--- a/src/polar_flow_server/api/keys.py
+++ b/src/polar_flow_server/api/keys.py
@@ -121,11 +121,7 @@ def _is_localhost(netloc: str) -> bool:
 def _allowed_callback_origins() -> set[str]:
     """Parse OAUTH_ALLOWED_CALLBACK_ORIGINS into normalized origins."""
     raw = settings.oauth_allowed_callback_origins or ""
-    return {
-        origin.strip().lower().rstrip("/")
-        for origin in raw.split(",")
-        if origin.strip()
-    }
+    return {origin.strip().lower().rstrip("/") for origin in raw.split(",") if origin.strip()}
 
 
 def _validate_callback_url(callback_url: str) -> tuple[bool, str]:
@@ -169,8 +165,7 @@ def _validate_callback_url(callback_url: str) -> tuple[bool, str]:
     allowed_origins = _allowed_callback_origins()
     if not allowed_origins:
         return False, (
-            "No callback origins are registered on this server "
-            "(set OAUTH_ALLOWED_CALLBACK_ORIGINS)"
+            "No callback origins are registered on this server (set OAUTH_ALLOWED_CALLBACK_ORIGINS)"
         )
     origin = f"{parsed.scheme}://{parsed.netloc}".lower()
     if origin not in allowed_origins:

--- a/src/polar_flow_server/core/config.py
+++ b/src/polar_flow_server/core/config.py
@@ -95,6 +95,13 @@ class Settings(BaseSettings):
         default=None,
         description="JWT secret for authentication (SaaS mode only)",
     )
+    oauth_allowed_callback_origins: str | None = Field(
+        default=None,
+        description="Comma-separated origins (scheme://host[:port]) allowed as "
+        "callback_url targets for the SaaS /oauth/start flow. The flow delivers "
+        "single-use auth codes to the callback, so it stays DISABLED until the "
+        "operator registers the client origins here.",
+    )
     jwt_algorithm: str = Field(default="HS256", description="JWT algorithm")
     jwt_expiry_minutes: int = Field(default=15, description="JWT access token expiry")
 

--- a/tests/test_oauth_callback_allowlist.py
+++ b/tests/test_oauth_callback_allowlist.py
@@ -76,9 +76,7 @@ class TestOAuthStartEndpoint:
         )
         assert response.status_code == 401
 
-    async def test_start_with_registered_callback_reaches_config_check(
-        self, app_client, allow
-    ):
+    async def test_start_with_registered_callback_reaches_config_check(self, app_client, allow):
         """Past validation, the next failure is unconfigured OAuth creds (404)
         — proving the allowlist let the registered origin through."""
         allow("https://app.example.com")
@@ -91,9 +89,7 @@ class TestOAuthStartEndpoint:
 
 
 class TestCallbackErrorHygiene:
-    async def test_exception_text_never_reaches_the_callback(
-        self, app_client, allow, monkeypatch
-    ):
+    async def test_exception_text_never_reaches_the_callback(self, app_client, allow, monkeypatch):
         """Force the token exchange to blow up with a sensitive message and
         assert only the generic 'server_error' token is redirected."""
         import httpx as httpx_module
@@ -124,9 +120,7 @@ class TestCallbackErrorHygiene:
 
         monkeypatch.setattr(httpx_module, "AsyncClient", ExplodingClient)
 
-        await _saas_oauth_states.set(
-            "test-state", "https://app.example.com/cb", None
-        )
+        await _saas_oauth_states.set("test-state", "https://app.example.com/cb", None)
         response = await app_client.get(
             "/oauth/callback",
             params={"code": "fake-code", "state": "test-state"},

--- a/tests/test_oauth_callback_allowlist.py
+++ b/tests/test_oauth_callback_allowlist.py
@@ -1,0 +1,140 @@
+"""SaaS OAuth callback allowlist + error hygiene tests (issue #56)."""
+
+import pytest
+
+from polar_flow_server.api.keys import _validate_callback_url
+from polar_flow_server.core.config import settings
+
+
+@pytest.fixture
+def allow(monkeypatch):
+    def set_value(value: str | None) -> None:
+        monkeypatch.setattr(settings, "oauth_allowed_callback_origins", value)
+
+    return set_value
+
+
+class TestCallbackAllowlist:
+    def test_rejected_when_no_origins_registered(self, allow):
+        allow(None)
+        ok, message = _validate_callback_url("https://app.example.com/callback")
+        assert not ok
+        assert "OAUTH_ALLOWED_CALLBACK_ORIGINS" in message
+
+    def test_registered_origin_passes_any_path(self, allow):
+        allow("https://app.example.com")
+        for path in ("/callback", "/oauth/done", "/x?y=z"):
+            ok, message = _validate_callback_url(f"https://app.example.com{path}")
+            assert ok, message
+
+    def test_unregistered_origin_rejected(self, allow):
+        allow("https://app.example.com")
+        ok, message = _validate_callback_url("https://evil.example.com/callback")
+        assert not ok
+        assert "not registered" in message
+
+    def test_subdomain_is_a_different_origin(self, allow):
+        allow("https://app.example.com")
+        ok, _ = _validate_callback_url("https://app.example.com.evil.net/cb")
+        assert not ok
+        ok, _ = _validate_callback_url("https://sub.app.example.com/cb")
+        assert not ok
+
+    def test_port_must_match(self, allow):
+        allow("https://app.example.com:8443")
+        assert _validate_callback_url("https://app.example.com:8443/cb")[0]
+        assert not _validate_callback_url("https://app.example.com/cb")[0]
+
+    def test_host_case_insensitive_and_trailing_slash_forgiven(self, allow):
+        allow("https://App.Example.com/, https://other.example.com")
+        assert _validate_callback_url("https://app.example.com/cb")[0]
+        assert _validate_callback_url("https://other.example.com/cb")[0]
+
+    def test_scheme_is_part_of_the_origin(self, allow, monkeypatch):
+        # http://localhost is dev-permitted at the scheme layer, but the
+        # https origin registration must not cover it
+        monkeypatch.setattr(settings, "base_url", None)
+        allow("https://localhost:8080")
+        assert not _validate_callback_url("http://localhost:8080/cb")[0]
+        allow("http://localhost:8080")
+        assert _validate_callback_url("http://localhost:8080/cb")[0]
+
+    def test_preexisting_shape_checks_still_apply(self, allow):
+        allow("https://app.example.com")
+        assert not _validate_callback_url("x" * 3000)[0]
+        assert not _validate_callback_url("ftp://app.example.com/cb")[0]
+        assert not _validate_callback_url("not a url")[0]
+
+
+class TestOAuthStartEndpoint:
+    async def test_start_rejects_unregistered_callback(self, app_client, allow):
+        allow("https://app.example.com")
+        response = await app_client.get(
+            "/oauth/start",
+            params={"callback_url": "https://evil.example.com/cb"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 401
+
+    async def test_start_with_registered_callback_reaches_config_check(
+        self, app_client, allow
+    ):
+        """Past validation, the next failure is unconfigured OAuth creds (404)
+        — proving the allowlist let the registered origin through."""
+        allow("https://app.example.com")
+        response = await app_client.get(
+            "/oauth/start",
+            params={"callback_url": "https://app.example.com/cb"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 404
+
+
+class TestCallbackErrorHygiene:
+    async def test_exception_text_never_reaches_the_callback(
+        self, app_client, allow, monkeypatch
+    ):
+        """Force the token exchange to blow up with a sensitive message and
+        assert only the generic 'server_error' token is redirected."""
+        import httpx as httpx_module
+
+        from polar_flow_server.api.keys import _saas_oauth_states
+        from polar_flow_server.core.database import async_session_maker
+        from polar_flow_server.core.security import token_encryption
+        from polar_flow_server.models.settings import AppSettings
+
+        async with async_session_maker() as db:
+            db.add(
+                AppSettings(
+                    id=1,
+                    polar_client_id="client-id",
+                    polar_client_secret_encrypted=token_encryption.encrypt("shh"),
+                )
+            )
+            await db.commit()
+
+        secret_detail = "password authentication failed for host db-internal-9000"
+
+        class ExplodingClient:
+            async def __aenter__(self):
+                raise RuntimeError(secret_detail)
+
+            async def __aexit__(self, *args):
+                return False
+
+        monkeypatch.setattr(httpx_module, "AsyncClient", ExplodingClient)
+
+        await _saas_oauth_states.set(
+            "test-state", "https://app.example.com/cb", None
+        )
+        response = await app_client.get(
+            "/oauth/callback",
+            params={"code": "fake-code", "state": "test-state"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+        location = response.headers["location"]
+        assert location.startswith("https://app.example.com/cb?")
+        assert "error=server_error" in location
+        assert "password" not in location
+        assert "db-internal" not in location


### PR DESCRIPTION
Closes #56. **Stacked on #94** — merge that first.

## Problems
1. `/oauth/start` accepted any well-formed https `callback_url` and later delivered the single-use temp code to it. Get a user to click an `/oauth/start` link with your callback and you receive their code → exchange it → their API key → their health data.
2. The callback exception path redirected `error=str(e)` to the third-party callback — raw internals (DB errors, hostnames) shipped off-server.

## Changes
- **`OAUTH_ALLOWED_CALLBACK_ORIGINS`** (comma-separated `scheme://host[:port]`): `callback_url` origins must be registered server-side. Exact origin match — scheme and port count, subdomains don't inherit. Host matching is case-insensitive.
- **Closed by default**: with no origins registered, `/oauth/start` refuses with a clear operator-facing message. ⚠️ Behaviour change for anyone using the SaaS flow today — they must set the env var. That open default *is* the vulnerability, so it shouldn't survive as a fallback. Self-hosted admin OAuth (`/admin/oauth/*`) is untouched.
- **Generic error tokens**: the exception path now redirects `error=server_error`; detail goes to the server log only.

## Testing
11 new tests:
- 8 unit tests on `_validate_callback_url`: no-registration refusal, registered origin passes any path, unregistered/subdomain-suffix tricks rejected, port + scheme part of the origin, case-insensitivity, pre-existing shape checks intact
- 2 integration: `/oauth/start` 401s an unregistered callback; a registered one passes validation (fails later on unconfigured creds, 404)
- **leak repro**: forced the token exchange to raise `'password authentication failed for host db-internal-9000'` — redirect contains only `error=server_error`, none of the text

Full suite: **107 passed**. ruff/mypy clean on changed files.