### PR TITLE
security: non-root container + required Postgres password, with a CI smoke test

### DIFF
--- a/.github/docker-compose.smoke.yml
+++ b/.github/docker-compose.smoke.yml
@@ -1,0 +1,5 @@
+# Overlay for the docker-smoke workflow: run the prod compose against the
+# image built in CI instead of the published one.
+services:
+  polar-flow-server:
+    image: polar-flow-server:smoke

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -1,0 +1,82 @@
+name: Docker Smoke Test
+
+# Builds the image and boots the REAL prod compose, then verifies the
+# properties the sandbox/unit tests can't: migrations run, /health answers,
+# the app runs as the unprivileged user, encryption keys survive a container
+# recreate, and the compose refuses to start without a Postgres password.
+on:
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile
+      - docker-entrypoint.sh
+      - docker-compose.prod.yml
+      - pyproject.toml
+      - uv.lock
+      - alembic/**
+      - src/**
+      - .github/workflows/docker-smoke.yml
+      - .github/docker-compose.smoke.yml
+  pull_request:
+    paths:
+      - Dockerfile
+      - docker-entrypoint.sh
+      - docker-compose.prod.yml
+      - pyproject.toml
+      - uv.lock
+      - alembic/**
+      - src/**
+      - .github/workflows/docker-smoke.yml
+      - .github/docker-compose.smoke.yml
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    env:
+      COMPOSE: docker compose -f docker-compose.prod.yml -f .github/docker-compose.smoke.yml
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build image
+        run: docker build -t polar-flow-server:smoke .
+
+      - name: Compose refuses to start without POSTGRES_PASSWORD
+        run: |
+          if $COMPOSE config > /dev/null 2>&1; then
+            echo "::error::compose accepted a missing POSTGRES_PASSWORD"
+            exit 1
+          fi
+          echo "OK: missing password rejected"
+
+      - name: Boot the stack
+        run: |
+          export POSTGRES_PASSWORD=smoke-test-password
+          $COMPOSE up -d --wait --wait-timeout 120
+
+      - name: Health endpoint answers
+        run: |
+          curl -fsS http://localhost:8000/health
+          echo
+
+      - name: App runs as the unprivileged user
+        run: |
+          export POSTGRES_PASSWORD=smoke-test-password
+          uid=$($COMPOSE exec -T polar-flow-server id -u)
+          echo "uid=$uid"
+          test "$uid" != "0"
+
+      - name: Encryption key survives a container recreate
+        run: |
+          export POSTGRES_PASSWORD=smoke-test-password
+          before=$($COMPOSE exec -T polar-flow-server sha256sum /data/keys/encryption.key)
+          $COMPOSE up -d --force-recreate --wait --wait-timeout 120 polar-flow-server
+          after=$($COMPOSE exec -T polar-flow-server sha256sum /data/keys/encryption.key)
+          echo "before: $before"
+          echo "after:  $after"
+          test "$before" = "$after"
+
+      - name: Dump logs on failure
+        if: failure()
+        run: |
+          export POSTGRES_PASSWORD=smoke-test-password
+          $COMPOSE logs || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,15 @@ COPY alembic/ alembic/
 # Install dependencies
 RUN uv sync --frozen --no-dev
 
+# Unprivileged runtime user — a container escape or code-exec bug shouldn't
+# hand out root.
+RUN groupadd --gid 1000 app \
+    && useradd --uid 1000 --gid app --create-home --home-dir /home/app app
+
 # Persistent data directory. KEY_DIR moves the auto-generated encryption/session
 # keys off the (ephemeral) container home dir — mount a volume over /data or the
 # keys are regenerated on every recreate and stored Polar tokens become unreadable.
-RUN mkdir -p /data/keys
+RUN mkdir -p /data/keys && chown -R app:app /data
 ENV KEY_DIR=/data/keys
 
 # Copy and set up entrypoint
@@ -32,6 +37,9 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # Expose port
 EXPOSE 8000
+
+USER app
+ENV HOME=/home/app
 
 # Run migrations then start server
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,13 +1,15 @@
 # Production Docker Compose
-# Just run: docker-compose -f docker-compose.prod.yml up -d
-# Then visit: http://localhost:8000/admin to configure
+# 1. Set a database password:  export POSTGRES_PASSWORD=$(openssl rand -hex 24)
+#    (or put POSTGRES_PASSWORD=... in a .env file next to this compose file)
+# 2. Run: docker-compose -f docker-compose.prod.yml up -d
+# 3. Visit: http://localhost:8000/admin to configure
 
 services:
   postgres:
     image: postgres:17-alpine
     environment:
       POSTGRES_USER: polar
-      POSTGRES_PASSWORD: polar
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD (e.g. export POSTGRES_PASSWORD=$(openssl rand -hex 24))}
       POSTGRES_DB: polar
     volumes:
       - postgres-data:/var/lib/postgresql/data
@@ -24,7 +26,7 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      DATABASE_URL: postgresql+asyncpg://polar:polar@postgres:5432/polar
+      DATABASE_URL: postgresql+asyncpg://polar:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD}@postgres:5432/polar
     volumes:
       # Persists auto-generated encryption/session keys (KEY_DIR=/data/keys).
       # Without this, every recreate regenerates the encryption key and all

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 set -e
 
+# Use the baked venv binaries directly: `uv run` wants to re-verify the lock
+# and (re)write .venv, which the unprivileged runtime user cannot and should
+# not do.
 echo "Running database migrations..."
-uv run alembic upgrade head
+/app/.venv/bin/alembic upgrade head
 
 echo "Starting polar-flow-server..."
-exec uv run polar-flow-server serve
+exec /app/.venv/bin/polar-flow-server serve


### PR DESCRIPTION
Closes #55. **Stacked on #93** (key persistence) — merge that first; the smoke test exercises both together.

## Changes
- **Non-root runtime**: the image creates uid-1000 `app`, owns `/data`, and runs everything as that user. The entrypoint now calls the baked venv binaries (`/app/.venv/bin/alembic`, `/app/.venv/bin/polar-flow-server`) directly — `uv run` wants to re-verify the lock and rewrite `.venv`, which the unprivileged user can't and shouldn't do.
- **No default DB password**: `docker-compose.prod.yml` now requires `POSTGRES_PASSWORD` (`${POSTGRES_PASSWORD:?...}`) and builds `DATABASE_URL` from it. Header comments show the one-liner (`export POSTGRES_PASSWORD=$(openssl rand -hex 24)`). ⚠️ Existing deployments must set it — with the old `polar` value if they want to keep their data volume, which the error message makes discoverable.
- **New `docker-smoke` workflow** — the sandbox I work in has no Docker, so the verification is CI-encoded permanently instead of a one-off local check. It builds the image and boots the *real* prod compose, then asserts:
  1. compose **refuses to start** without `POSTGRES_PASSWORD`
  2. migrations run and `/health` answers
  3. the app process is **not uid 0**
  4. `sha256(/data/keys/encryption.key)` is **identical after a forced container recreate** — end-to-end proof of #50's token-bricking fix, not just the unit tests

## Notes
- Dev compose still mounts `~/.polar-flow:/data/keys` (uid 1000 matches the typical host user).
- If #93 merges and someone deploys before this lands, their `app-data` volume is root-owned; recreate it or `chown -R 1000:1000` (called out since no release ships between them).

Unit suite unaffected: **96 passed** on this branch. The smoke workflow runs on this PR itself — its green check is the boot test.