### PR TITLE
Fix SpO2 tiles (nonexistent model fields) and remove dead post-sync OOB swaps

### DIFF
--- a/src/polar_flow_server/admin/routes.py
+++ b/src/polar_flow_server/admin/routes.py
@@ -914,11 +914,6 @@ async def trigger_manual_sync(request: Request[Any, Any, Any], session: AsyncSes
             trigger=SyncTrigger.MANUAL,
         )
 
-        # Get updated counts
-        sleep_count = (await session.execute(select(func.count(Sleep.id)))).scalar() or 0
-        exercise_count = (await session.execute(select(func.count(Exercise.id)))).scalar() or 0
-        activity_count = (await session.execute(select(func.count(Activity.id)))).scalar() or 0
-
         # Check sync status
         if sync_log.status == "partial":
             # Partial success - some endpoints worked, some failed
@@ -928,9 +923,6 @@ async def trigger_manual_sync(request: Request[Any, Any, Any], session: AsyncSes
                 context={
                     "results": sync_log.records_synced or {},
                     "errors": errors,
-                    "sleep_count": sleep_count,
-                    "exercise_count": exercise_count,
-                    "activity_count": activity_count,
                 },
             )
         elif sync_log.status == "failed":
@@ -954,9 +946,6 @@ async def trigger_manual_sync(request: Request[Any, Any, Any], session: AsyncSes
             template_name="admin/partials/sync_success.html",
             context={
                 "results": sync_log.records_synced or {},
-                "sleep_count": sleep_count,
-                "exercise_count": exercise_count,
-                "activity_count": activity_count,
             },
         )
     except Exception as e:

--- a/src/polar_flow_server/templates/admin/dashboard.html
+++ b/src/polar_flow_server/templates/admin/dashboard.html
@@ -261,7 +261,7 @@
             <div class="p-4">
                 <div class="text-fuchsia-700 text-xs font-medium uppercase">SpO2</div>
                 <div class="text-fuchsia-900 text-2xl font-bold mt-1">
-                    {% if latest_spo2 and latest_spo2.spo2_avg %}{{ latest_spo2.spo2_avg|round(0) }}<span class="text-sm font-normal ml-1">%</span>{% else %}--{% endif %}
+                    {% if latest_spo2 %}{{ latest_spo2.blood_oxygen_percent }}<span class="text-sm font-normal ml-1">%</span>{% else %}--{% endif %}
                 </div>
             </div>
         </div>
@@ -649,10 +649,10 @@
         <div>
             <div class="text-gray-500 text-xs uppercase">SpO2 ({{ latest_spo2.test_time.strftime('%m/%d') }})</div>
             <div class="text-xl font-bold text-purple-700">
-                {{ latest_spo2.spo2_avg|round(1) if latest_spo2.spo2_avg else '--' }}<span class="text-sm font-normal ml-1">%</span>
+                {{ latest_spo2.blood_oxygen_percent }}<span class="text-sm font-normal ml-1">%</span>
             </div>
-            {% if latest_spo2.spo2_min %}
-            <div class="text-xs text-gray-500">Min: {{ latest_spo2.spo2_min }}%</div>
+            {% if latest_spo2.spo2_class %}
+            <div class="text-xs {% if latest_spo2.spo2_class != 'NORMAL' %}text-red-600{% else %}text-gray-500{% endif %}">{{ latest_spo2.spo2_class|title }}</div>
             {% endif %}
         </div>
         {% endif %}

--- a/src/polar_flow_server/templates/admin/partials/sync_partial.html
+++ b/src/polar_flow_server/templates/admin/partials/sync_partial.html
@@ -34,14 +34,6 @@
                 </ul>
             </div>
 
-            <div class="mt-3 text-xs text-yellow-600">
-                Total records: {{ sleep_count }} sleep, {{ exercise_count }} exercises, {{ activity_count }} activities
-            </div>
         </div>
     </div>
 </div>
-
-<!-- Update stat cards via out-of-band swap -->
-<dd id="sleep-count" hx-swap-oob="true" class="text-2xl font-semibold text-gray-900">{{ sleep_count }}</dd>
-<dd id="exercise-count" hx-swap-oob="true" class="text-2xl font-semibold text-gray-900">{{ exercise_count }}</dd>
-<dd id="activity-count" hx-swap-oob="true" class="text-2xl font-semibold text-gray-900">{{ activity_count }}</dd>

--- a/src/polar_flow_server/templates/admin/partials/sync_success.html
+++ b/src/polar_flow_server/templates/admin/partials/sync_success.html
@@ -14,14 +14,6 @@
                     {% endfor %}
                 </ul>
             </div>
-            <div class="mt-3 text-xs text-green-600">
-                Total records: {{ sleep_count }} sleep, {{ exercise_count }} exercises, {{ activity_count }} activities
-            </div>
         </div>
     </div>
 </div>
-
-<!-- Update stat cards via out-of-band swap -->
-<dd id="sleep-count" hx-swap-oob="true" class="text-2xl font-semibold text-gray-900">{{ sleep_count }}</dd>
-<dd id="exercise-count" hx-swap-oob="true" class="text-2xl font-semibold text-gray-900">{{ exercise_count }}</dd>
-<dd id="activity-count" hx-swap-oob="true" class="text-2xl font-semibold text-gray-900">{{ activity_count }}</dd>

--- a/tests/test_dashboard_render.py
+++ b/tests/test_dashboard_render.py
@@ -1,0 +1,104 @@
+"""Dashboard template render smoke tests (issues #58 and #65).
+
+#58: the SpO2 tiles referenced model fields that don't exist (spo2_avg /
+spo2_min), so Jinja's default Undefined silently rendered "--" forever.
+These tests render the real dashboard through the real app with a real
+SpO2 row and assert the value actually appears — a wrong field name fails.
+
+#65: the post-sync partials emitted hx-swap-oob swaps for elements removed
+in the dashboard redesign; the swaps (and the count queries feeding them)
+are gone.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+
+async def _login(app_client, admin_account) -> None:
+    response = await app_client.post(
+        "/admin/login",
+        data={"email": admin_account["email"], "password": admin_account["password"]},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+
+
+async def _seed_spo2(blood_oxygen_percent: int = 97, spo2_class: str = "NORMAL") -> None:
+    from polar_flow_server.core.database import async_session_maker
+    from polar_flow_server.models.spo2 import SpO2
+
+    async with async_session_maker() as session:
+        session.add(
+            SpO2(
+                user_id="test-user",
+                device_id="polar-loop-test",
+                test_time=datetime(2026, 8, 1, 7, 30, tzinfo=UTC),
+                blood_oxygen_percent=blood_oxygen_percent,
+                spo2_class=spo2_class,
+            )
+        )
+        await session.commit()
+
+
+class TestSpO2Tiles:
+    async def test_spo2_value_renders_on_dashboard(self, app_client, admin_account):
+        """The stat card shows the stored blood oxygen value, not '--'."""
+        await _login(app_client, admin_account)
+        await _seed_spo2(blood_oxygen_percent=97)
+
+        response = await app_client.get("/admin/dashboard")
+        assert response.status_code == 200
+        assert "97" in response.text
+        # The SpO2 stat card guard is just the row's presence now — with a
+        # row seeded there must be no '--' fallback inside the SpO2 card.
+        spo2_card = response.text.split('text-fuchsia-700 text-xs font-medium uppercase">SpO2')[1]
+        spo2_card = spo2_card.split("</div>")[1]
+        assert "--" not in spo2_card
+        assert "97" in spo2_card
+
+    async def test_spo2_classification_renders(self, app_client, admin_account):
+        """The biosensing panel shows the real spo2_class field."""
+        await _login(app_client, admin_account)
+        await _seed_spo2(blood_oxygen_percent=91, spo2_class="LOW")
+
+        response = await app_client.get("/admin/dashboard")
+        assert response.status_code == 200
+        assert "Low" in response.text  # spo2_class | title
+
+    async def test_dashboard_never_references_removed_fields(self):
+        """Regression guard: the dead field names must not creep back in."""
+        from pathlib import Path
+
+        import polar_flow_server
+
+        template = (
+            Path(polar_flow_server.__file__).parent / "templates" / "admin" / "dashboard.html"
+        ).read_text()
+        assert "spo2_avg" not in template
+        assert "spo2_min" not in template
+
+
+class TestDeadOobSwapsRemoved:
+    @pytest.mark.parametrize("partial", ["sync_success.html", "sync_partial.html"])
+    def test_partials_have_no_oob_swaps(self, partial):
+        """The swap targets were removed in the #44 redesign; the swaps too."""
+        from pathlib import Path
+
+        import polar_flow_server
+
+        text = (
+            Path(polar_flow_server.__file__).parent / "templates" / "admin" / "partials" / partial
+        ).read_text()
+        assert "hx-swap-oob" not in text
+        assert "sleep_count" not in text
+
+    def test_oob_targets_do_not_exist_anywhere(self):
+        """If someone reintroduces the IDs AND the swaps, this documents the pair."""
+        from pathlib import Path
+
+        import polar_flow_server
+
+        templates = Path(polar_flow_server.__file__).parent / "templates"
+        for page in templates.rglob("*.html"):
+            assert 'id="sleep-count"' not in page.read_text()


### PR DESCRIPTION
## What

Two dashboard-template bugs, both dead references left behind by earlier refactors:

- **#58 (HIGH, user-visible):** the SpO2 stat card and Biosensing panel read `spo2_avg` / `spo2_min`, which have never existed on the `SpO2` model. Jinja's default `Undefined` is falsy, so both tiles rendered `--` forever — even sat next to a non-zero `spo2_count`. Now they read the real `blood_oxygen_percent` column, and the phantom "Min" line becomes the stored `spo2_class` (Normal/Low, red when not normal).
- **#65:** `sync_success.html` / `sync_partial.html` still emitted `hx-swap-oob` swaps for `#sleep-count` etc. — elements removed in the #44 redesign. HTMX logged a console error and discarded them, and the sync route ran three count queries per manual sync purely to feed the dead swaps. Removed the swaps, the "Total records" line built on them, and the three queries.

## Testing

New `tests/test_dashboard_render.py` (6 tests) — the render smoke tests #58 called for:
- Renders the real dashboard through the full app (login + seeded SpO2 row) and asserts the stored value actually appears — a wrong field name now fails the suite instead of silently showing `--`
- Asserts `spo2_class` renders
- Regression guards: the dead field names and OOB swaps can't creep back

Full suite: 160 passed locally.

Fixes #58
Fixes #65