### PR TITLE
Propagate real biosensing sync errors instead of swallowing them at debug level

### DIFF
--- a/src/polar_flow_server/services/sync.py
+++ b/src/polar_flow_server/services/sync.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import structlog
 from polar_flow import PolarFlow
-from polar_flow.exceptions import PolarFlowError
+from polar_flow.exceptions import NotFoundError, PolarFlowError
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -654,10 +654,10 @@ class SyncService:
 
                 await self.session.execute(stmt)
                 count += 1
-            except Exception as e:
-                # Skip days with errors
+            except NotFoundError as e:
+                # No data recorded for this day - normal, keep going.
                 self.logger.debug(
-                    "Error fetching continuous HR for date",
+                    "No continuous HR for date",
                     date=str(fetch_date),
                     error=str(e),
                 )
@@ -683,7 +683,8 @@ class SyncService:
 
         try:
             spo2_data = await client.biosensing.get_spo2()
-        except Exception as e:
+        except NotFoundError as e:
+            # Genuinely no data / device doesn't support it - not an error.
             self.logger.debug("SpO2 sync skipped", error=str(e))
             return 0
 
@@ -716,7 +717,8 @@ class SyncService:
 
         try:
             ecg_data = await client.biosensing.get_ecg()
-        except Exception as e:
+        except NotFoundError as e:
+            # Genuinely no data / device doesn't support it - not an error.
             self.logger.debug("ECG sync skipped", error=str(e))
             return 0
 
@@ -749,7 +751,8 @@ class SyncService:
 
         try:
             temp_data = await client.biosensing.get_body_temperature()
-        except Exception as e:
+        except NotFoundError as e:
+            # Genuinely no data / device doesn't support it - not an error.
             self.logger.debug("Body temperature sync skipped", error=str(e))
             return 0
 
@@ -782,7 +785,8 @@ class SyncService:
 
         try:
             temp_data = await client.biosensing.get_skin_temperature()
-        except Exception as e:
+        except NotFoundError as e:
+            # Genuinely no data / device doesn't support it - not an error.
             self.logger.debug("Skin temperature sync skipped", error=str(e))
             return 0
 

--- a/tests/test_biosensing_error_propagation.py
+++ b/tests/test_biosensing_error_propagation.py
@@ -1,0 +1,140 @@
+"""Biosensing sync errors must reach result.errors (issue #60).
+
+The four biosensing sync methods (and the per-day continuous HR loop) used
+to catch *all* exceptions — including 401/403/429 — log at debug, and return
+0, so SyncLog recorded 'success' while endpoints were silently failing.
+
+Only NotFoundError (genuinely no data / device doesn't support the endpoint)
+may be swallowed now; anything else propagates to sync_user's per-endpoint
+handler like the other nine endpoints.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from polar_flow.exceptions import (
+    AuthenticationError,
+    NotFoundError,
+    PolarFlowError,
+    RateLimitError,
+)
+
+from polar_flow_server.services.sync import SyncService
+
+
+def _mock_client() -> AsyncMock:
+    """A client where every endpoint succeeds with no data."""
+    client = AsyncMock()
+    client.sleep.list = AsyncMock(return_value=[])
+    client.recharge.list = AsyncMock(return_value=[])
+    client.activity.list = AsyncMock(return_value=[])
+    client.exercises.list = AsyncMock(return_value=[])
+    client.cardio_load.list = AsyncMock(return_value=[])
+    client.sleepwise.get_alertness = AsyncMock(return_value=[])
+    client.sleepwise.get_bedtime = AsyncMock(return_value=[])
+    client.activity_samples.list = AsyncMock(return_value=[])
+    client.continuous_hr.get = AsyncMock(return_value=None)
+    client.biosensing.get_spo2 = AsyncMock(return_value=[])
+    client.biosensing.get_ecg = AsyncMock(return_value=[])
+    client.biosensing.get_body_temperature = AsyncMock(return_value=[])
+    client.biosensing.get_skin_temperature = AsyncMock(return_value=[])
+    return client
+
+
+async def _run_sync(async_session, client: AsyncMock):
+    sync_service = SyncService(async_session)
+    with patch("polar_flow_server.services.sync.PolarFlow") as MockPolarFlow:
+        mock_context = AsyncMock()
+        mock_context.__aenter__ = AsyncMock(return_value=client)
+        mock_context.__aexit__ = AsyncMock(return_value=None)
+        MockPolarFlow.return_value = mock_context
+        return await sync_service.sync_user(
+            user_id="test_user",
+            polar_token="fake_token",
+            recalculate_baselines=False,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("sdk_method", "endpoint"),
+    [
+        ("get_spo2", "spo2"),
+        ("get_ecg", "ecg"),
+        ("get_body_temperature", "body_temperature"),
+        ("get_skin_temperature", "skin_temperature"),
+    ],
+)
+async def test_auth_error_reaches_result_errors(async_session, sdk_method, endpoint):
+    """A 403 is a real failure — it must not be logged away as 'skipped'."""
+    client = _mock_client()
+    setattr(
+        client.biosensing,
+        sdk_method,
+        AsyncMock(
+            side_effect=AuthenticationError(
+                "API error 403: Forbidden", status_code=403, endpoint=f"/v3/{endpoint}"
+            )
+        ),
+    )
+
+    result = await _run_sync(async_session, client)
+
+    assert endpoint in result.errors
+    # The rest of the sync still completed
+    assert result.records["sleep"] == 0
+    assert "sleep" not in result.errors
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_error_reaches_result_errors(async_session):
+    client = _mock_client()
+    client.biosensing.get_ecg = AsyncMock(
+        side_effect=RateLimitError("API error 429: Too Many Requests", retry_after=60)
+    )
+
+    result = await _run_sync(async_session, client)
+
+    assert "ecg" in result.errors
+    assert "spo2" not in result.errors
+
+
+@pytest.mark.asyncio
+async def test_not_found_is_still_swallowed(async_session):
+    """No data / unsupported device stays a quiet skip, not an error."""
+    client = _mock_client()
+    client.biosensing.get_spo2 = AsyncMock(
+        side_effect=NotFoundError("API error 404: Not Found", status_code=404)
+    )
+
+    result = await _run_sync(async_session, client)
+
+    assert result.errors == {}
+    assert result.records["spo2"] == 0
+
+
+@pytest.mark.asyncio
+async def test_continuous_hr_real_error_propagates(async_session):
+    """A real API error mid-loop must fail the endpoint, not skip the day."""
+    client = _mock_client()
+    client.continuous_hr.get = AsyncMock(
+        side_effect=PolarFlowError("API error 500: Server Error", status_code=500)
+    )
+
+    result = await _run_sync(async_session, client)
+
+    assert "continuous_hr" in result.errors
+
+
+@pytest.mark.asyncio
+async def test_continuous_hr_not_found_day_is_skipped(async_session):
+    """Days with no recording keep the loop going and stay off the errors."""
+    client = _mock_client()
+    client.continuous_hr.get = AsyncMock(
+        side_effect=NotFoundError("API error 404: Not Found", status_code=404)
+    )
+
+    result = await _run_sync(async_session, client)
+
+    assert "continuous_hr" not in result.errors
+    assert result.records["continuous_hr"] == 0


### PR DESCRIPTION
## What

`_sync_spo2` / `_sync_ecg` / `_sync_body_temperature` / `_sync_skin_temperature` (and the per-day `_sync_continuous_hr` loop) caught **all** exceptions — including 401/403/429 — logged at `debug`, and returned 0. Errors never reached `result.errors`, so `SyncLog` recorded `success` while endpoints were failing, and the admin's "why did SpO2 stop syncing?" question was unanswerable.

Now only `NotFoundError` (genuinely no data / device doesn't support the endpoint) is swallowed. Real API errors propagate to `sync_user`'s per-endpoint handler — same treatment as the other nine endpoints — so they show up in `result.errors`, the sync partial/error UI, and the sync log.

## Testing

New `tests/test_biosensing_error_propagation.py` (8 tests), using the repo's established mock-client pattern:
- 403 on each of the four biosensing endpoints → lands in `result.errors`, rest of sync continues
- 429 → lands in `result.errors`
- `NotFoundError` → still a quiet skip (no error, count 0), for both biosensing and per-day continuous HR
- Real 500 mid-continuous-HR-loop → fails the endpoint into `result.errors` instead of skipping the day

Existing sync error-handling tests (#19) still green. Full suite: 162 passed locally.

Fixes #60