### PR TITLE
Guard against concurrent syncs for the same user (Sync Now double-click / scheduler overlap)

### DIFF
--- a/src/polar_flow_server/admin/routes.py
+++ b/src/polar_flow_server/admin/routes.py
@@ -57,6 +57,7 @@ from polar_flow_server.models.sync_log import SyncLog, SyncTrigger
 from polar_flow_server.models.temperature import BodyTemperature, SkinTemperature
 from polar_flow_server.models.user import User
 from polar_flow_server.services.scheduler import get_scheduler
+from polar_flow_server.services.sync_guard import SyncInProgressError
 from polar_flow_server.services.sync_orchestrator import SyncOrchestrator
 
 logger = logging.getLogger(__name__)
@@ -957,6 +958,16 @@ async def trigger_manual_sync(request: Request[Any, Any, Any], session: AsyncSes
                 "sleep_count": sleep_count,
                 "exercise_count": exercise_count,
                 "activity_count": activity_count,
+            },
+        )
+    except SyncInProgressError:
+        return Template(
+            template_name="admin/partials/sync_error.html",
+            context={
+                "error": (
+                    "A sync is already running. Wait for it to finish — "
+                    "it will appear in the sync history below."
+                )
             },
         )
     except Exception as e:

--- a/src/polar_flow_server/api/sync.py
+++ b/src/polar_flow_server/api/sync.py
@@ -3,12 +3,14 @@
 from typing import Annotated, Any
 
 from litestar import Router, post
+from litestar.exceptions import HTTPException
 from litestar.params import Parameter
-from litestar.status_codes import HTTP_200_OK
+from litestar.status_codes import HTTP_200_OK, HTTP_409_CONFLICT
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from polar_flow_server.core.auth import per_user_api_key_guard
 from polar_flow_server.services.sync import SyncService
+from polar_flow_server.services.sync_guard import SyncInProgressError, sync_slot
 
 
 @post(
@@ -38,11 +40,18 @@ async def trigger_sync(
     """
     sync_service = SyncService(session)
 
-    sync_result = await sync_service.sync_user(
-        user_id=user_id,
-        polar_token=polar_token,
-        days=days,
-    )
+    try:
+        with sync_slot(user_id):
+            sync_result = await sync_service.sync_user(
+                user_id=user_id,
+                polar_token=polar_token,
+                days=days,
+            )
+    except SyncInProgressError as e:
+        raise HTTPException(
+            status_code=HTTP_409_CONFLICT,
+            detail="A sync is already running for this user",
+        ) from e
 
     return {
         "status": "partial" if sync_result.has_errors else "success",

--- a/src/polar_flow_server/services/sync_guard.py
+++ b/src/polar_flow_server/services/sync_guard.py
@@ -1,0 +1,44 @@
+"""In-process per-user sync guard.
+
+At most one sync per user at a time, whatever triggered it — the admin
+"Sync Now" button, the scheduler, or the REST trigger endpoint. The server
+runs a single worker (see cli.py), so a process-local registry is
+authoritative. asyncio is single-threaded and there is no await between
+the check and the add, so acquisition is race-free.
+"""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+
+class SyncInProgressError(Exception):
+    """A sync for this user is already running."""
+
+
+_in_flight: set[str] = set()
+
+
+@contextmanager
+def sync_slot(user_id: str) -> Iterator[None]:
+    """Hold the user's sync slot for the duration of a sync.
+
+    Raises:
+        SyncInProgressError: if a sync for this user is already running.
+    """
+    if user_id in _in_flight:
+        raise SyncInProgressError(f"A sync is already running for user {user_id}")
+    _in_flight.add(user_id)
+    try:
+        yield
+    finally:
+        _in_flight.discard(user_id)
+
+
+def is_syncing(user_id: str) -> bool:
+    """Whether a sync for this user is currently in flight."""
+    return user_id in _in_flight
+
+
+def reset_for_tests() -> None:
+    """Clear the registry (test isolation only)."""
+    _in_flight.clear()

--- a/src/polar_flow_server/services/sync_orchestrator.py
+++ b/src/polar_flow_server/services/sync_orchestrator.py
@@ -61,6 +61,7 @@ from polar_flow_server.services.baseline import BaselineService
 from polar_flow_server.services.pattern import PatternService
 from polar_flow_server.services.sync import SyncService
 from polar_flow_server.services.sync_error_handler import SyncErrorHandler
+from polar_flow_server.services.sync_guard import SyncInProgressError, sync_slot
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -219,7 +220,9 @@ class SyncOrchestrator:
         """Sync a single user with full audit logging.
 
         Creates a SyncLog entry, performs the sync, handles errors,
-        and marks analytics completion.
+        and marks analytics completion. At most one sync runs per user at
+        a time — a concurrent call (double-clicked Sync Now, scheduler
+        overlapping a manual sync) raises before any SyncLog is created.
 
         Args:
             user_id: User identifier
@@ -230,7 +233,27 @@ class SyncOrchestrator:
 
         Returns:
             Completed SyncLog with results
+
+        Raises:
+            SyncInProgressError: a sync for this user is already running.
         """
+        with sync_slot(user_id):
+            return await self._sync_user_locked(
+                user_id=user_id,
+                polar_token=polar_token,
+                trigger=trigger,
+                priority=priority,
+                recalculate_analytics=recalculate_analytics,
+            )
+
+    async def _sync_user_locked(
+        self,
+        user_id: str,
+        polar_token: str,
+        trigger: SyncTrigger,
+        priority: SyncPriority | None,
+        recalculate_analytics: bool,
+    ) -> SyncLog:
         job_id = str(uuid.uuid4())
         log = self.logger.bind(user_id=user_id, job_id=job_id, trigger=trigger.value)
 
@@ -453,6 +476,12 @@ class SyncOrchestrator:
                 # Update rate limiter from results
                 self.rate_limiter.update_from_sync_log(sync_log)
 
+            except SyncInProgressError:
+                log.info(
+                    "Sync already in flight for user, skipping",
+                    user_id=user.polar_user_id,
+                )
+                continue
             except Exception as e:
                 log.error(
                     "Failed to sync user",

--- a/src/polar_flow_server/templates/admin/settings.html
+++ b/src/polar_flow_server/templates/admin/settings.html
@@ -274,7 +274,8 @@
                     hx-target="#sync-result"
                     hx-swap="innerHTML"
                     hx-indicator="#sync-spinner"
-                    class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                    hx-disabled-elt="this"
+                    class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                     <svg id="sync-spinner" class="htmx-indicator animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
                         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>

--- a/tests/test_sync_guard.py
+++ b/tests/test_sync_guard.py
@@ -1,0 +1,155 @@
+"""Concurrent-sync guard tests (issue #63).
+
+Double-clicking "Sync Now" (or a manual sync overlapping a scheduled run)
+used to run two full sync cycles concurrently — doubled Polar API usage
+and interleaved SyncLogs. APScheduler's max_instances=1 only ever guarded
+the scheduled job against itself.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from polar_flow_server.models.sync_log import SyncLog, SyncTrigger
+from polar_flow_server.services.sync_guard import (
+    SyncInProgressError,
+    is_syncing,
+    reset_for_tests,
+    sync_slot,
+)
+from polar_flow_server.services.sync_orchestrator import SyncOrchestrator
+
+
+@pytest.fixture(autouse=True)
+def _clean_guard():
+    reset_for_tests()
+    yield
+    reset_for_tests()
+
+
+class TestSyncSlot:
+    def test_second_acquire_raises(self):
+        with sync_slot("user-a"):
+            assert is_syncing("user-a")
+            with pytest.raises(SyncInProgressError):
+                with sync_slot("user-a"):
+                    pass
+
+    def test_different_users_do_not_collide(self):
+        with sync_slot("user-a"), sync_slot("user-b"):
+            assert is_syncing("user-a")
+            assert is_syncing("user-b")
+
+    def test_slot_released_on_exit(self):
+        with sync_slot("user-a"):
+            pass
+        assert not is_syncing("user-a")
+        with sync_slot("user-a"):
+            pass
+
+    def test_slot_released_on_exception(self):
+        with pytest.raises(RuntimeError), sync_slot("user-a"):
+            raise RuntimeError("sync blew up")
+        assert not is_syncing("user-a")
+
+
+class TestOrchestratorGuard:
+    @pytest.mark.asyncio
+    async def test_refuses_while_slot_held_and_creates_no_synclog(self, async_session):
+        """The refusal happens before any SyncLog row exists."""
+        from sqlalchemy import func, select
+
+        orchestrator = SyncOrchestrator(async_session)
+        with sync_slot("user-a"):
+            with pytest.raises(SyncInProgressError):
+                await orchestrator.sync_user(
+                    user_id="user-a",
+                    polar_token="fake",
+                    trigger=SyncTrigger.MANUAL,
+                )
+
+        count = (await async_session.execute(select(func.count(SyncLog.id)))).scalar()
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_concurrent_manual_syncs_one_wins(self, async_session):
+        """The double-click shape: two syncs at once, exactly one runs."""
+        orchestrator = SyncOrchestrator(async_session)
+        ran = []
+
+        async def slow_sync(**kwargs):
+            await asyncio.sleep(0.05)
+            ran.append(kwargs["user_id"])
+            return SyncLog(user_id=kwargs["user_id"], job_id="job", trigger="manual")
+
+        with patch.object(orchestrator, "_sync_user_locked", AsyncMock(side_effect=slow_sync)):
+            results = await asyncio.gather(
+                orchestrator.sync_user(user_id="user-a", polar_token="fake"),
+                orchestrator.sync_user(user_id="user-a", polar_token="fake"),
+                return_exceptions=True,
+            )
+
+        refused = [r for r in results if isinstance(r, SyncInProgressError)]
+        completed = [r for r in results if isinstance(r, SyncLog)]
+        assert len(refused) == 1
+        assert len(completed) == 1
+        assert ran == ["user-a"]
+        assert not is_syncing("user-a")
+
+    @pytest.mark.asyncio
+    async def test_slot_released_after_sync_failure(self, async_session):
+        """A failing sync must not wedge the user's slot forever."""
+        orchestrator = SyncOrchestrator(async_session)
+
+        with patch.object(
+            orchestrator,
+            "_sync_user_locked",
+            AsyncMock(side_effect=RuntimeError("network down")),
+        ):
+            with pytest.raises(RuntimeError):
+                await orchestrator.sync_user(user_id="user-a", polar_token="fake")
+
+        assert not is_syncing("user-a")
+
+
+class TestAdminSyncRoute:
+    async def _login_with_csrf(self, app_client, admin_account) -> str:
+        response = await app_client.get("/admin", follow_redirects=False)
+        assert response.status_code in (200, 303)
+        token = app_client.cookies.get("csrf_token")
+        assert token
+        response = await app_client.post(
+            "/admin/login",
+            data={"email": admin_account["email"], "password": admin_account["password"]},
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+        return token
+
+    @pytest.mark.asyncio
+    async def test_sync_now_refused_while_in_flight(self, app_client, admin_account):
+        """With the connected user's slot held, Sync Now says so instead of
+        starting a second cycle."""
+        from polar_flow_server.core.database import async_session_maker
+        from polar_flow_server.core.security import token_encryption
+        from polar_flow_server.models.user import User
+
+        async with async_session_maker() as session:
+            session.add(
+                User(
+                    id="user-connected",
+                    polar_user_id="connected",
+                    access_token_encrypted=token_encryption.encrypt("fake-token"),
+                    is_active=True,
+                )
+            )
+            await session.commit()
+
+        csrf = await self._login_with_csrf(app_client, admin_account)
+
+        with sync_slot("connected"):
+            response = await app_client.post("/admin/sync", headers={"X-CSRF-Token": csrf})
+
+        assert response.status_code == 200
+        assert "already running" in response.text


### PR DESCRIPTION
## What

`/admin/sync` ran the orchestrator with no in-flight check — double-clicking **Sync Now** (the button wasn't disabled during flight) or clicking during a scheduled run doubled Polar API usage and produced interleaved `SyncLog`s. APScheduler's `max_instances=1` only guards the scheduled job against itself.

- New `services/sync_guard.py`: an in-process per-user sync slot (`sync_slot(user_id)` context manager + `SyncInProgressError`). The server is single-worker by documented constraint (`cli.py`), so a process-local registry is authoritative, and asyncio's single thread makes acquisition race-free.
- `SyncOrchestrator.sync_user` acquires the slot **before** creating a `SyncLog`, so a refused sync leaves no bogus audit rows. Covers every trigger that goes through the orchestrator (manual, scheduler).
- The scheduler queue loop catches the refusal and skips that user with an info log instead of an error.
- The REST trigger (`POST /users/{id}/sync/trigger`) wraps `SyncService` in the same slot and returns **409 Conflict** when a sync is in flight.
- The admin route renders a friendly "a sync is already running" notice instead of a raw error.
- The Sync Now button gets `hx-disabled-elt="this"` (+ disabled styling) so the UI can't double-fire in the first place (htmx 2.0.4 supports it).

## Testing

New `tests/test_sync_guard.py` (8 tests):
- Slot semantics: second acquire raises, distinct users don't collide, released on exit and on exception
- Orchestrator: refusal happens before any `SyncLog` row exists; two concurrent `sync_user` calls → exactly one runs, one refused, slot released after; a failing sync can't wedge the slot
- Integration through the real app: with the connected user's slot held, `POST /admin/sync` (CSRF'd, logged in) returns the "already running" notice

Full suite: 162 passed locally.

Fixes #63