### PR TITLE
Make rate-limit tracking live and retry transient sync errors

### DIFF
--- a/src/polar_flow_server/services/sync.py
+++ b/src/polar_flow_server/services/sync.py
@@ -1,6 +1,7 @@
 """Polar data sync service."""
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import date, timedelta
 from typing import Any
@@ -147,7 +148,7 @@ class SyncService:
         self,
         result: SyncResult,
         endpoint: str,
-        fn: Any,
+        fn: Callable[..., Awaitable[int]],
         *args: Any,
         **kwargs: Any,
     ) -> int:

--- a/src/polar_flow_server/services/sync.py
+++ b/src/polar_flow_server/services/sync.py
@@ -1,12 +1,13 @@
 """Polar data sync service."""
 
+import asyncio
 from dataclasses import dataclass, field
 from datetime import date, timedelta
 from typing import Any
 
 import structlog
 from polar_flow import PolarFlow
-from polar_flow.exceptions import NotFoundError, PolarFlowError
+from polar_flow.exceptions import NotFoundError, PolarFlowError, RateLimitError
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -22,8 +23,10 @@ from polar_flow_server.models.sleep import Sleep
 from polar_flow_server.models.sleepwise_alertness import SleepWiseAlertness
 from polar_flow_server.models.sleepwise_bedtime import SleepWiseBedtime
 from polar_flow_server.models.spo2 import SpO2
+from polar_flow_server.models.sync_log import SyncErrorType
 from polar_flow_server.models.temperature import BodyTemperature, SkinTemperature
 from polar_flow_server.services.baseline import BaselineService
+from polar_flow_server.services.sync_error_handler import SyncErrorHandler
 from polar_flow_server.transformers import (
     ActivitySamplesTransformer,
     ActivityTransformer,
@@ -42,6 +45,9 @@ from polar_flow_server.transformers import (
 
 logger = structlog.get_logger()
 
+# Single-retry backoff for transient endpoint failures (5xx / network blips).
+TRANSIENT_RETRY_BACKOFF_SECONDS = 2.0
+
 
 @dataclass
 class SyncResult:
@@ -56,6 +62,9 @@ class SyncResult:
 
     records: dict[str, int] = field(default_factory=dict)
     errors: dict[str, str] = field(default_factory=dict)
+    # Seconds Polar asked us to back off (worst Retry-After seen), if any
+    # endpoint hit a 429 during this sync.
+    rate_limited_for: int | None = None
 
     @property
     def has_errors(self) -> bool:
@@ -132,6 +141,57 @@ class SyncService:
         """
         self.session = session
         self.logger = logger.bind(service="sync")
+        self.error_handler = SyncErrorHandler()
+
+    async def _call_with_retry(
+        self,
+        result: SyncResult,
+        endpoint: str,
+        fn: Any,
+        *args: Any,
+        **kwargs: Any,
+    ) -> int:
+        """Run one endpoint sync, retrying once after a short backoff when
+        the failure is transient (Polar 5xx, timeout, connection blip).
+
+        Rate limits are deliberately not retried here: Retry-After windows
+        are minutes long, so the 429 is recorded on the result instead and
+        the orchestrator's tracker holds the next cycle back (issue #64).
+        """
+        try:
+            return await fn(*args, **kwargs)
+        except RateLimitError as e:
+            result.rate_limited_for = max(result.rate_limited_for or 0, e.retry_after)
+            raise
+        except Exception as e:
+            # NB: key must not be "endpoint" - classify()'s own logging
+            # passes endpoint= alongside **context and would collide.
+            sync_error = self.error_handler.classify(e, context={"sync_endpoint": endpoint})
+            # Generic PolarFlowErrors classify as API_ERROR whatever the
+            # status; only server-side (5xx) or status-less failures are
+            # worth a retry - a 4xx will just fail identically again.
+            status = getattr(e, "status_code", None)
+            retryable = sync_error.is_transient and (
+                sync_error.error_type in (SyncErrorType.API_UNAVAILABLE, SyncErrorType.API_TIMEOUT)
+                or (
+                    sync_error.error_type == SyncErrorType.API_ERROR
+                    and (status is None or status >= 500)
+                )
+            )
+            if not retryable:
+                raise
+            self.logger.info(
+                "Transient error, retrying once",
+                endpoint=endpoint,
+                error=str(e),
+                backoff_seconds=TRANSIENT_RETRY_BACKOFF_SECONDS,
+            )
+            await asyncio.sleep(TRANSIENT_RETRY_BACKOFF_SECONDS)
+            try:
+                return await fn(*args, **kwargs)
+            except RateLimitError as retry_exc:
+                result.rate_limited_for = max(result.rate_limited_for or 0, retry_exc.retry_after)
+                raise
 
     async def sync_user(
         self,
@@ -191,7 +251,9 @@ class SyncService:
         async with PolarFlow(access_token=polar_token) as client:
             # Sync sleep data
             try:
-                result.records["sleep"] = await self._sync_sleep(client, user_id, days)
+                result.records["sleep"] = await self._call_with_retry(
+                    result, "sleep", self._sync_sleep, client, user_id, days
+                )
             except Exception as e:
                 error_msg = _format_polar_error(e, "sleep")
                 result.errors["sleep"] = error_msg
@@ -199,7 +261,9 @@ class SyncService:
 
             # Sync nightly recharge
             try:
-                result.records["recharge"] = await self._sync_recharge(client, user_id)
+                result.records["recharge"] = await self._call_with_retry(
+                    result, "recharge", self._sync_recharge, client, user_id
+                )
             except Exception as e:
                 error_msg = _format_polar_error(e, "recharge")
                 result.errors["recharge"] = error_msg
@@ -207,7 +271,9 @@ class SyncService:
 
             # Sync daily activity
             try:
-                result.records["activity"] = await self._sync_activity(client, user_id, days)
+                result.records["activity"] = await self._call_with_retry(
+                    result, "activity", self._sync_activity, client, user_id, days
+                )
             except Exception as e:
                 error_msg = _format_polar_error(e, "activity")
                 result.errors["activity"] = error_msg
@@ -215,7 +281,9 @@ class SyncService:
 
             # Sync exercises
             try:
-                result.records["exercises"] = await self._sync_exercises(client, user_id)
+                result.records["exercises"] = await self._call_with_retry(
+                    result, "exercises", self._sync_exercises, client, user_id
+                )
             except Exception as e:
                 error_msg = _format_polar_error(e, "exercises")
                 result.errors["exercises"] = error_msg
@@ -224,7 +292,9 @@ class SyncService:
             # Sync cardio load (requires SDK >= 1.3.0)
             if hasattr(client, "cardio_load"):
                 try:
-                    result.records["cardio_load"] = await self._sync_cardio_load(client, user_id)
+                    result.records["cardio_load"] = await self._call_with_retry(
+                        result, "cardio_load", self._sync_cardio_load, client, user_id
+                    )
                 except Exception as e:
                     error_msg = _format_polar_error(e, "cardio_load")
                     result.errors["cardio_load"] = error_msg
@@ -233,8 +303,12 @@ class SyncService:
             # Sync SleepWise alertness (requires SDK >= 1.3.0)
             if hasattr(client, "sleepwise"):
                 try:
-                    result.records["sleepwise_alertness"] = await self._sync_sleepwise_alertness(
-                        client, user_id
+                    result.records["sleepwise_alertness"] = await self._call_with_retry(
+                        result,
+                        "sleepwise_alertness",
+                        self._sync_sleepwise_alertness,
+                        client,
+                        user_id,
                     )
                 except Exception as e:
                     error_msg = _format_polar_error(e, "sleepwise_alertness")
@@ -244,8 +318,8 @@ class SyncService:
                     )
 
                 try:
-                    result.records["sleepwise_bedtime"] = await self._sync_sleepwise_bedtime(
-                        client, user_id
+                    result.records["sleepwise_bedtime"] = await self._call_with_retry(
+                        result, "sleepwise_bedtime", self._sync_sleepwise_bedtime, client, user_id
                     )
                 except Exception as e:
                     error_msg = _format_polar_error(e, "sleepwise_bedtime")
@@ -257,8 +331,13 @@ class SyncService:
             # Sync activity samples (requires SDK >= 1.3.0)
             if hasattr(client, "activity_samples"):
                 try:
-                    result.records["activity_samples"] = await self._sync_activity_samples(
-                        client, user_id, days
+                    result.records["activity_samples"] = await self._call_with_retry(
+                        result,
+                        "activity_samples",
+                        self._sync_activity_samples,
+                        client,
+                        user_id,
+                        days,
                     )
                 except Exception as e:
                     error_msg = _format_polar_error(e, "activity_samples")
@@ -270,8 +349,8 @@ class SyncService:
             # Sync continuous heart rate (requires SDK >= 1.3.0)
             if hasattr(client, "continuous_hr"):
                 try:
-                    result.records["continuous_hr"] = await self._sync_continuous_hr(
-                        client, user_id, days
+                    result.records["continuous_hr"] = await self._call_with_retry(
+                        result, "continuous_hr", self._sync_continuous_hr, client, user_id, days
                     )
                 except Exception as e:
                     error_msg = _format_polar_error(e, "continuous_hr")
@@ -283,22 +362,26 @@ class SyncService:
             # Sync biosensing data (requires SDK >= 1.4.0 and compatible devices)
             if hasattr(client, "biosensing"):
                 try:
-                    result.records["spo2"] = await self._sync_spo2(client, user_id)
+                    result.records["spo2"] = await self._call_with_retry(
+                        result, "spo2", self._sync_spo2, client, user_id
+                    )
                 except Exception as e:
                     error_msg = _format_polar_error(e, "spo2")
                     result.errors["spo2"] = error_msg
                     self.logger.warning("SpO2 sync failed", user_id=user_id, error=error_msg)
 
                 try:
-                    result.records["ecg"] = await self._sync_ecg(client, user_id)
+                    result.records["ecg"] = await self._call_with_retry(
+                        result, "ecg", self._sync_ecg, client, user_id
+                    )
                 except Exception as e:
                     error_msg = _format_polar_error(e, "ecg")
                     result.errors["ecg"] = error_msg
                     self.logger.warning("ECG sync failed", user_id=user_id, error=error_msg)
 
                 try:
-                    result.records["body_temperature"] = await self._sync_body_temperature(
-                        client, user_id
+                    result.records["body_temperature"] = await self._call_with_retry(
+                        result, "body_temperature", self._sync_body_temperature, client, user_id
                     )
                 except Exception as e:
                     error_msg = _format_polar_error(e, "body_temperature")
@@ -308,8 +391,8 @@ class SyncService:
                     )
 
                 try:
-                    result.records["skin_temperature"] = await self._sync_skin_temperature(
-                        client, user_id
+                    result.records["skin_temperature"] = await self._call_with_retry(
+                        result, "skin_temperature", self._sync_skin_temperature, client, user_id
                     )
                 except Exception as e:
                     error_msg = _format_polar_error(e, "skin_temperature")

--- a/src/polar_flow_server/services/sync_orchestrator.py
+++ b/src/polar_flow_server/services/sync_orchestrator.py
@@ -97,7 +97,25 @@ class RateLimitTracker:
         self.limit_15m: int | None = None
         self.limit_24h: int | None = None
         self.last_updated: datetime | None = None
+        self.rate_limited_until: datetime | None = None
         self.logger = logger.bind(component="rate_limit_tracker")
+
+    def note_rate_limited(self, retry_after_seconds: int) -> None:
+        """Record a real 429 from Polar: hold syncs until Retry-After passes.
+
+        This is the tracker's live data source. Per-window quota capture
+        from X-RateLimit-* headers needs SDK support (the SDK reads them
+        but only logs); until then the 429s themselves drive the backoff.
+        """
+        until = datetime.now(UTC) + timedelta(seconds=retry_after_seconds)
+        if self.rate_limited_until is None or until > self.rate_limited_until:
+            self.rate_limited_until = until
+        self.last_updated = datetime.now(UTC)
+        self.logger.warning(
+            "Rate limited by Polar API, backing off",
+            retry_after_seconds=retry_after_seconds,
+            rate_limited_until=self.rate_limited_until.isoformat(),
+        )
 
     def update_from_sync_log(self, sync_log: SyncLog) -> None:
         """Update limits from a completed sync log.
@@ -121,6 +139,12 @@ class RateLimitTracker:
         Returns:
             True if we can safely attempt a sync
         """
+        # A recorded 429 holds everything until its Retry-After passes
+        if self.rate_limited_until is not None:
+            if datetime.now(UTC) < self.rate_limited_until:
+                return False
+            self.rate_limited_until = None
+
         # If we don't have limit info yet, allow sync to get headers
         if self.remaining_15m is None or self.remaining_24h is None:
             return True
@@ -139,6 +163,12 @@ class RateLimitTracker:
         """
         if self.can_sync_now():
             return 0
+
+        # Honour an active Retry-After window exactly
+        if self.rate_limited_until is not None:
+            remaining = (self.rate_limited_until - datetime.now(UTC)).total_seconds()
+            if remaining > 0:
+                return int(remaining) + 1
 
         # If 15-min limit is exhausted, wait up to 15 minutes
         if self.remaining_15m is not None and self.remaining_15m < self.CALLS_PER_SYNC_ESTIMATE:
@@ -173,7 +203,15 @@ class RateLimitTracker:
             "can_sync": self.can_sync_now(),
             "safe_batch_size": self.get_safe_batch_size(),
             "last_updated": self.last_updated.isoformat() if self.last_updated else None,
+            "rate_limited_until": (
+                self.rate_limited_until.isoformat() if self.rate_limited_until else None
+            ),
         }
+
+
+# The scheduler constructs a fresh SyncOrchestrator every cycle, so backoff
+# state must live at module level to survive between cycles.
+shared_rate_limit_tracker = RateLimitTracker()
 
 
 class SyncOrchestrator:
@@ -206,7 +244,7 @@ class SyncOrchestrator:
         self.session = session
         self.sync_service = SyncService(session)
         self.error_handler = SyncErrorHandler()
-        self.rate_limiter = RateLimitTracker()
+        self.rate_limiter = shared_rate_limit_tracker
         self.logger = logger.bind(component="sync_orchestrator")
 
     async def sync_user(
@@ -276,6 +314,10 @@ class SyncOrchestrator:
                 polar_token=polar_token,
                 recalculate_baselines=False,  # We'll do it ourselves
             )
+
+            # A 429 anywhere in the sync drives the tracker's backoff window
+            if sync_result.rate_limited_for:
+                self.rate_limiter.note_rate_limited(sync_result.rate_limited_for)
 
             # API calls = number of data types with records (each requires 1+ API call)
             api_calls = len([v for v in sync_result.records.values() if v > 0])
@@ -353,9 +395,6 @@ class SyncOrchestrator:
                 error=sync_error.message,
                 is_transient=sync_error.is_transient,
             )
-
-        # Note: Rate limit tracking from Polar API headers would require
-        # SDK-level changes. Current implementation uses conservative estimates.
 
         # Commit the sync log
         await self.session.commit()

--- a/tests/test_rate_limit_retry.py
+++ b/tests/test_rate_limit_retry.py
@@ -1,0 +1,191 @@
+"""Rate-limit tracking and transient retry tests (issue #64).
+
+Before this, RateLimitTracker.can_sync_now() always returned True (nothing
+ever fed it), SyncErrorHandler's is_transient/retry_after were computed but
+never consumed, and any 429 or API blip simply failed the endpoint.
+
+Now: transient failures (5xx/timeouts) get a single short-backoff retry,
+429s feed a process-wide backoff window that the scheduler honours, and
+the Retry-After value is respected rather than hammered.
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from polar_flow.exceptions import AuthenticationError, PolarFlowError, RateLimitError
+
+from polar_flow_server.services.sync import SyncResult, SyncService
+from polar_flow_server.services.sync_orchestrator import (
+    RateLimitTracker,
+    SyncOrchestrator,
+    shared_rate_limit_tracker,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_shared_tracker():
+    shared_rate_limit_tracker.rate_limited_until = None
+    yield
+    shared_rate_limit_tracker.rate_limited_until = None
+
+
+def _mock_client() -> AsyncMock:
+    client = AsyncMock()
+    client.sleep.list = AsyncMock(return_value=[])
+    client.recharge.list = AsyncMock(return_value=[])
+    client.activity.list = AsyncMock(return_value=[])
+    client.exercises.list = AsyncMock(return_value=[])
+    client.cardio_load.list = AsyncMock(return_value=[])
+    client.sleepwise.get_alertness = AsyncMock(return_value=[])
+    client.sleepwise.get_bedtime = AsyncMock(return_value=[])
+    client.activity_samples.list = AsyncMock(return_value=[])
+    client.continuous_hr.get = AsyncMock(return_value=None)
+    client.biosensing.get_spo2 = AsyncMock(return_value=[])
+    client.biosensing.get_ecg = AsyncMock(return_value=[])
+    client.biosensing.get_body_temperature = AsyncMock(return_value=[])
+    client.biosensing.get_skin_temperature = AsyncMock(return_value=[])
+    return client
+
+
+async def _run_sync(async_session, client: AsyncMock) -> SyncResult:
+    sync_service = SyncService(async_session)
+    with (
+        patch("polar_flow_server.services.sync.PolarFlow") as MockPolarFlow,
+        patch("polar_flow_server.services.sync.asyncio.sleep", AsyncMock()),
+    ):
+        mock_context = AsyncMock()
+        mock_context.__aenter__ = AsyncMock(return_value=client)
+        mock_context.__aexit__ = AsyncMock(return_value=None)
+        MockPolarFlow.return_value = mock_context
+        return await sync_service.sync_user(
+            user_id="test_user",
+            polar_token="fake_token",
+            recalculate_baselines=False,
+        )
+
+
+class TestTransientRetry:
+    @pytest.mark.asyncio
+    async def test_transient_500_is_retried_once_and_recovers(self, async_session):
+        client = _mock_client()
+        client.sleep.list = AsyncMock(
+            side_effect=[
+                PolarFlowError("API error 500: Server Error", status_code=500),
+                [],
+            ]
+        )
+
+        result = await _run_sync(async_session, client)
+
+        assert client.sleep.list.call_count == 2
+        assert "sleep" not in result.errors
+
+    @pytest.mark.asyncio
+    async def test_persistent_500_fails_after_one_retry(self, async_session):
+        client = _mock_client()
+        client.sleep.list = AsyncMock(
+            side_effect=PolarFlowError("API error 500: Server Error", status_code=500)
+        )
+
+        result = await _run_sync(async_session, client)
+
+        assert client.sleep.list.call_count == 2
+        assert "sleep" in result.errors
+
+    @pytest.mark.asyncio
+    async def test_non_transient_403_is_not_retried(self, async_session):
+        client = _mock_client()
+        client.sleep.list = AsyncMock(
+            side_effect=AuthenticationError("API error 403: Forbidden", status_code=403)
+        )
+
+        result = await _run_sync(async_session, client)
+
+        assert client.sleep.list.call_count == 1
+        assert "sleep" in result.errors
+
+    @pytest.mark.asyncio
+    async def test_429_is_not_retried_and_records_backoff(self, async_session):
+        """Retry-After windows are minutes long — hammering is the wrong
+        move. The 429 is recorded so the orchestrator can back off."""
+        client = _mock_client()
+        client.sleep.list = AsyncMock(side_effect=RateLimitError("API error 429", retry_after=120))
+
+        result = await _run_sync(async_session, client)
+
+        assert client.sleep.list.call_count == 1
+        assert "sleep" in result.errors
+        assert result.rate_limited_for == 120
+
+    @pytest.mark.asyncio
+    async def test_worst_retry_after_wins(self, async_session):
+        client = _mock_client()
+        client.sleep.list = AsyncMock(side_effect=RateLimitError("429", retry_after=60))
+        client.activity.list = AsyncMock(side_effect=RateLimitError("429", retry_after=900))
+
+        result = await _run_sync(async_session, client)
+
+        assert result.rate_limited_for == 900
+
+
+class TestRateLimitTracker:
+    def test_note_rate_limited_blocks_syncs(self):
+        tracker = RateLimitTracker()
+        assert tracker.can_sync_now()
+
+        tracker.note_rate_limited(300)
+
+        assert not tracker.can_sync_now()
+        assert 0 < tracker.get_wait_time_seconds() <= 301
+
+    def test_cooldown_expires(self):
+        tracker = RateLimitTracker()
+        tracker.rate_limited_until = datetime.now(UTC) - timedelta(seconds=1)
+
+        assert tracker.can_sync_now()
+        assert tracker.rate_limited_until is None
+
+    def test_longer_window_is_kept(self):
+        tracker = RateLimitTracker()
+        tracker.note_rate_limited(600)
+        first = tracker.rate_limited_until
+        tracker.note_rate_limited(60)
+
+        assert tracker.rate_limited_until == first
+
+    @pytest.mark.asyncio
+    async def test_scheduler_cycle_skips_during_cooldown(self, async_session):
+        """process_sync_queue's can_sync_now() gate is finally reachable."""
+        shared_rate_limit_tracker.note_rate_limited(300)
+        orchestrator = SyncOrchestrator(async_session)
+
+        results = await orchestrator.process_sync_queue()
+
+        assert results == []
+
+
+class TestOrchestratorFeedsTracker:
+    @pytest.mark.asyncio
+    async def test_429_during_sync_sets_shared_backoff(self, app_client):
+        """A rate-limited sync must arm the shared tracker for the next
+        cycle (postgres-backed: SyncLog timestamps need tz-aware storage)."""
+        from polar_flow_server.core.database import async_session_maker
+
+        async with async_session_maker() as session:
+            orchestrator = SyncOrchestrator(session)
+            with patch.object(
+                orchestrator.sync_service,
+                "sync_user",
+                AsyncMock(
+                    return_value=SyncResult(
+                        records={"sleep": 0},
+                        errors={"sleep": "Rate limited"},
+                        rate_limited_for=120,
+                    )
+                ),
+            ):
+                await orchestrator.sync_user(user_id="user-a", polar_token="fake")
+
+        assert shared_rate_limit_tracker.rate_limited_until is not None
+        assert not shared_rate_limit_tracker.can_sync_now()


### PR DESCRIPTION
## What

#64 offered two paths: wire the tracker up or delete it. Investigation first: the SDK reads the `X-RateLimit-*` headers but only logs them — no public hook — so **header-based quota capture genuinely needs SDK changes** (the old code comment was right). But the 429's `Retry-After` *is* surfaced via `RateLimitError`, so the tracker can run on real data without touching the SDK:

- **Tracker goes live + process-wide:** `RateLimitTracker` was recreated per orchestrator instance (the scheduler builds a fresh orchestrator every cycle), so even captured state would have died between cycles. It's now a module-level singleton with a `note_rate_limited(retry_after)` API. A 429 anywhere in a sync records its Retry-After on the `SyncResult`; the orchestrator arms the tracker; the scheduler's existing `can_sync_now()` gate — previously unreachable dead code — now actually holds cycles back until the window passes, and `get_wait_time_seconds()` honours the exact Retry-After.
- **Transient retry:** every endpoint call now goes through `_call_with_retry`, which consumes `SyncErrorHandler.is_transient` (computed-but-never-consumed until now). Polar 5xx / timeouts / connection blips get **one** retry after a 2s backoff; 4xx fail immediately (they'd fail identically again); **429s are deliberately not retried** — their windows are minutes long, hammering burns quota for nothing.
- Header-based per-window quota capture stays an honest SDK follow-up rather than a shim reaching into the SDK's private httpx client.

## Testing

New `tests/test_rate_limit_retry.py` (10 tests):
- 500 then success → retried once, no error recorded; persistent 500 → exactly one retry then recorded
- 403 → not retried; 429 → not retried, worst Retry-After recorded on the result
- Tracker: `note_rate_limited` blocks syncs, cooldown expires, longer window wins
- Scheduler cycle returns empty during cooldown (the gate is reachable at last)
- Orchestrator → shared tracker feeding, through the real postgres-backed SyncLog path

Full suite: 164 passed locally.

Fixes #64