### PR TITLE
Detail endpoints: 404 instead of 200 null, and make exercise detail reachable

### DIFF
--- a/src/polar_flow_server/api/data.py
+++ b/src/polar_flow_server/api/data.py
@@ -4,6 +4,7 @@ from datetime import date, timedelta
 from typing import Annotated, Any
 
 from litestar import Router, get
+from litestar.exceptions import NotFoundException
 from litestar.openapi.spec import Example
 from litestar.params import Parameter
 from litestar.status_codes import HTTP_200_OK
@@ -79,7 +80,7 @@ async def get_activity_by_date(
         ),
     ],
     session: AsyncSession,
-) -> dict[str, Any] | None:
+) -> dict[str, Any]:
     """Get activity data for a specific date."""
     stmt = select(Activity).where(
         Activity.user_id == user_id,
@@ -89,7 +90,7 @@ async def get_activity_by_date(
     r = result.scalar_one_or_none()
 
     if not r:
-        return None
+        raise NotFoundException(detail=f"No activity data for {target_date}")
 
     return {
         "date": str(r.date),
@@ -246,21 +247,23 @@ async def get_exercises_list(
     ]
 
 
-@get("/users/{user_id:str}/exercises/{exercise_id:int}", status_code=HTTP_200_OK)
+@get("/users/{user_id:str}/exercises/{exercise_id:str}", status_code=HTTP_200_OK)
 async def get_exercise_detail(
     user_id: str,
     exercise_id: Annotated[
-        int,
+        str,
         Parameter(
             description="Exercise ID (from the exercises list endpoint)",
             examples=[
-                Example(value=1, summary="First exercise"),
-                Example(value=42, summary="Example exercise ID"),
+                Example(
+                    value="9f2b8e4a-1c3d-4e5f-8a6b-7c8d9e0f1a2b",
+                    summary="Exercise ID from the list endpoint",
+                ),
             ],
         ),
     ],
     session: AsyncSession,
-) -> dict[str, Any] | None:
+) -> dict[str, Any]:
     """Get detailed exercise data."""
     stmt = select(Exercise).where(
         Exercise.user_id == user_id,
@@ -270,7 +273,7 @@ async def get_exercise_detail(
     r = result.scalar_one_or_none()
 
     if not r:
-        return None
+        raise NotFoundException(detail=f"Exercise {exercise_id} not found")
 
     return {
         "id": r.id,

--- a/tests/test_detail_endpoints_404.py
+++ b/tests/test_detail_endpoints_404.py
@@ -1,0 +1,111 @@
+"""Detail endpoints must 404 on missing data, not return `200 null` (#66).
+
+`GET /users/{id}/activity/{date}` and `GET /users/{id}/exercises/{id}`
+returned `None` — HTTP 200 with body `null` — when nothing matched, so
+clients couldn't distinguish "no data" from success and the OpenAPI schema
+(which advertises an object) lied.
+"""
+
+from datetime import UTC, date, datetime, timedelta
+
+import pytest
+
+
+async def _seed_user_with_key() -> str:
+    """Connected user + a real API key; returns the raw key for headers."""
+    from polar_flow_server.core.api_keys import create_api_key_for_user
+    from polar_flow_server.core.database import async_session_maker
+    from polar_flow_server.models.user import User
+
+    async with async_session_maker() as session:
+        session.add(
+            User(
+                id="user-1",
+                polar_user_id="polar-1",
+                access_token_encrypted="not-a-real-token",
+                is_active=True,
+            )
+        )
+        await session.flush()
+        _, raw_key = await create_api_key_for_user(
+            user_id="polar-1", name="test key", session=session
+        )
+        await session.commit()
+    return raw_key
+
+
+async def _seed_activity_and_exercise() -> int:
+    """One activity for yesterday and one exercise; returns the exercise id."""
+    from polar_flow_server.core.database import async_session_maker
+    from polar_flow_server.models.activity import Activity
+    from polar_flow_server.models.exercise import Exercise
+
+    async with async_session_maker() as session:
+        session.add(
+            Activity(
+                id="activity-1",
+                user_id="polar-1",
+                date=date.today() - timedelta(days=1),
+                steps=12345,
+            )
+        )
+        session.add(
+            Exercise(
+                id="exercise-1",
+                user_id="polar-1",
+                polar_exercise_id="polar-ex-1",
+                start_time=datetime(2026, 8, 1, 10, 0, tzinfo=UTC),
+                sport="RUNNING",
+            )
+        )
+        await session.commit()
+    return 0
+
+
+class TestActivityByDate:
+    @pytest.mark.asyncio
+    async def test_missing_date_is_404(self, app_client):
+        key = await _seed_user_with_key()
+        response = await app_client.get(
+            "/api/v1/users/polar-1/activity/2020-01-01", headers={"X-API-Key": key}
+        )
+        assert response.status_code == 404
+        # Our handler's message, not the router's generic "Not Found"
+        assert "No activity data" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_existing_date_is_200_object(self, app_client):
+        key = await _seed_user_with_key()
+        await _seed_activity_and_exercise()
+        target = (date.today() - timedelta(days=1)).isoformat()
+
+        response = await app_client.get(
+            f"/api/v1/users/polar-1/activity/{target}", headers={"X-API-Key": key}
+        )
+        assert response.status_code == 200
+        assert response.json()["steps"] == 12345
+
+
+class TestExerciseDetail:
+    @pytest.mark.asyncio
+    async def test_missing_exercise_is_404(self, app_client):
+        key = await _seed_user_with_key()
+        response = await app_client.get(
+            "/api/v1/users/polar-1/exercises/no-such-exercise", headers={"X-API-Key": key}
+        )
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+        assert "no-such-exercise" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_existing_exercise_is_200_object(self, app_client):
+        """Exercise ids are UUID strings; the old {exercise_id:int} route
+        could never match a real id from the list endpoint."""
+        key = await _seed_user_with_key()
+        await _seed_activity_and_exercise()
+
+        response = await app_client.get(
+            "/api/v1/users/polar-1/exercises/exercise-1", headers={"X-API-Key": key}
+        )
+        assert response.status_code == 200
+        assert response.json()["sport"] == "RUNNING"


### PR DESCRIPTION
## What

- **#66:** `get_activity_by_date` and `get_exercise_detail` returned `None` → HTTP 200 with body `null` when nothing matched. Clients couldn't distinguish "no data" from success and the OpenAPI schema (which advertises an object) lied. Both now `raise NotFoundException` → the standard 404 error shape, with a useful `detail` message.
- **Bonus bug found while writing the tests:** the exercise detail route was declared `{exercise_id:int}`, but `Exercise.id` is a **UUID string** (`String(36)`, `default=generate_uuid`) — exactly what the exercises *list* endpoint returns as `id`. So a real id could never match the route (router-level 404), and an integer probe 500'd on the varchar comparison. The endpoint was effectively unreachable. The param is `{exercise_id:str}` now, and the OpenAPI example shows a UUID instead of `42`.

## Testing

New `tests/test_detail_endpoints_404.py` (4 tests) through the real app with a real API key (the data router is key-guarded):
- Missing activity date → 404 with *our* detail message (assertions distinguish it from the router's generic "Not Found", which is how the old `:int` bug was caught)
- Existing activity date → 200 with the object
- Missing exercise id → 404 with the id in the message
- Existing exercise (string id, list-endpoint style) → 200 — fails on the old `:int` route

Full suite: 158 passed locally.

Fixes #66