### PR TITLE
Consistent UTC-labelled timestamps, dynamic sync-config card, correct revoke copy

### DIFF
--- a/src/polar_flow_server/admin/routes.py
+++ b/src/polar_flow_server/admin/routes.py
@@ -1269,6 +1269,7 @@ async def admin_settings(
             "pattern_count": pattern_count,
             # Sync scheduler
             "sync_interval_minutes": settings.sync_interval_minutes,
+            "sync_days_lookback": settings.sync_days_lookback,
             "scheduler_status": scheduler_status,
             "recent_sync_logs": recent_sync_logs,
             "sync_stats": sync_stats,

--- a/src/polar_flow_server/app.py
+++ b/src/polar_flow_server/app.py
@@ -2,7 +2,9 @@
 
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 import structlog
 from advanced_alchemy.config.asyncio import AsyncSessionConfig
@@ -31,6 +33,28 @@ from polar_flow_server.core.setup_token import announce_setup_token
 from polar_flow_server.middleware import RateLimitHeadersMiddleware, SecurityHeadersMiddleware
 from polar_flow_server.routes import root_redirect
 from polar_flow_server.services.scheduler import SyncScheduler, set_scheduler
+
+
+def format_utc(value: Any, fmt: str = "%Y-%m-%d %H:%M") -> str:
+    """Jinja filter: render a stored-UTC timestamp consistently, labelled UTC.
+
+    All persisted datetimes are UTC; templates used to strftime them with no
+    label (read as local) and one spot printed raw isoformat (issue #68/#73).
+    Accepts datetime, isoformat string, or None.
+    """
+    if not value:
+        return "--"
+    if isinstance(value, str):
+        try:
+            value = datetime.fromisoformat(value)
+        except ValueError:
+            return value
+    return value.strftime(fmt) + " UTC"
+
+
+def _register_template_filters(engine: JinjaTemplateEngine) -> None:
+    engine.engine.filters["utc_dt"] = format_utc
+
 
 # Configure structured logging
 structlog.configure(
@@ -172,6 +196,7 @@ def create_app() -> Litestar:
         template_config=TemplateConfig(
             directory=templates_dir,
             engine=JinjaTemplateEngine,
+            engine_callback=_register_template_filters,
         ),
         plugins=[
             SQLAlchemyPlugin(

--- a/src/polar_flow_server/app.py
+++ b/src/polar_flow_server/app.py
@@ -4,7 +4,6 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import Any
 
 import structlog
 from advanced_alchemy.config.asyncio import AsyncSessionConfig
@@ -35,7 +34,7 @@ from polar_flow_server.routes import root_redirect
 from polar_flow_server.services.scheduler import SyncScheduler, set_scheduler
 
 
-def format_utc(value: Any, fmt: str = "%Y-%m-%d %H:%M") -> str:
+def format_utc(value: datetime | str | None, fmt: str = "%Y-%m-%d %H:%M") -> str:
     """Jinja filter: render a stored-UTC timestamp consistently, labelled UTC.
 
     All persisted datetimes are UTC; templates used to strftime them with no
@@ -46,9 +45,10 @@ def format_utc(value: Any, fmt: str = "%Y-%m-%d %H:%M") -> str:
         return "--"
     if isinstance(value, str):
         try:
-            value = datetime.fromisoformat(value)
+            parsed = datetime.fromisoformat(value)
         except ValueError:
             return value
+        value = parsed
     return value.strftime(fmt) + " UTC"
 
 

--- a/src/polar_flow_server/templates/admin/dashboard.html
+++ b/src/polar_flow_server/templates/admin/dashboard.html
@@ -14,22 +14,22 @@
             {% if last_sync.status == 'success' %}
             <span class="inline-flex shrink-0 items-center whitespace-nowrap px-3 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 border border-green-200">
                 <span class="w-2 h-2 rounded-full bg-green-500 mr-1.5"></span>
-                Synced {{ (last_sync.completed_at or last_sync.started_at).strftime('%m/%d %H:%M') }}
+                Synced {{ (last_sync.completed_at or last_sync.started_at) | utc_dt('%m/%d %H:%M') }}
             </span>
             {% elif last_sync.status == 'partial' %}
             <span class="inline-flex shrink-0 items-center whitespace-nowrap px-3 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800 border border-yellow-200">
                 <span class="w-2 h-2 rounded-full bg-yellow-500 mr-1.5"></span>
-                Partial sync {{ (last_sync.completed_at or last_sync.started_at).strftime('%m/%d %H:%M') }}
+                Partial sync {{ (last_sync.completed_at or last_sync.started_at) | utc_dt('%m/%d %H:%M') }}
             </span>
             {% elif last_sync.status == 'skipped' %}
             <span class="inline-flex shrink-0 items-center whitespace-nowrap px-3 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-700 border border-gray-200">
                 <span class="w-2 h-2 rounded-full bg-gray-400 mr-1.5"></span>
-                Sync skipped {{ (last_sync.completed_at or last_sync.started_at).strftime('%m/%d %H:%M') }}
+                Sync skipped {{ (last_sync.completed_at or last_sync.started_at) | utc_dt('%m/%d %H:%M') }}
             </span>
             {% elif last_sync.status == 'failed' %}
             <span class="inline-flex shrink-0 items-center whitespace-nowrap px-3 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800 border border-red-200">
                 <span class="w-2 h-2 rounded-full bg-red-500 mr-1.5"></span>
-                Sync failed {{ (last_sync.completed_at or last_sync.started_at).strftime('%m/%d %H:%M') }}
+                Sync failed {{ (last_sync.completed_at or last_sync.started_at) | utc_dt('%m/%d %H:%M') }}
             </span>
             {% else %}
             <span class="inline-flex shrink-0 items-center whitespace-nowrap px-3 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800 border border-blue-200">

--- a/src/polar_flow_server/templates/admin/settings.html
+++ b/src/polar_flow_server/templates/admin/settings.html
@@ -95,7 +95,7 @@
                         <p class="text-sm font-medium text-blue-900">Connected to Polar Flow</p>
                         <p class="text-sm text-blue-700 mt-1">User ID: {{ connected_user.polar_user_id }}</p>
                         {% if connected_user.last_sync_at %}
-                        <p class="text-xs text-blue-600 mt-1">Last sync: {{ connected_user.last_sync_at.strftime('%Y-%m-%d %H:%M') }}</p>
+                        <p class="text-xs text-blue-600 mt-1">Last sync: {{ connected_user.last_sync_at | utc_dt }}</p>
                         {% endif %}
                     </div>
                 </div>
@@ -155,12 +155,12 @@
         <div class="grid grid-cols-2 gap-4 text-sm">
             <div class="p-4 border border-gray-200 rounded-lg">
                 <p class="text-gray-600 mb-1">Sync Interval</p>
-                <p class="text-2xl font-bold text-gray-900">1 hour</p>
+                <p class="text-2xl font-bold text-gray-900">{% if sync_interval_minutes % 60 == 0 %}{{ sync_interval_minutes // 60 }} hour{% if sync_interval_minutes // 60 != 1 %}s{% endif %}{% else %}{{ sync_interval_minutes }} minutes{% endif %}</p>
                 <p class="text-xs text-gray-500 mt-1">Automatic sync frequency</p>
             </div>
             <div class="p-4 border border-gray-200 rounded-lg">
                 <p class="text-gray-600 mb-1">Days Lookback</p>
-                <p class="text-2xl font-bold text-gray-900">30 days</p>
+                <p class="text-2xl font-bold text-gray-900">{{ sync_days_lookback }} days</p>
                 <p class="text-xs text-gray-500 mt-1">Default data history to fetch</p>
             </div>
         </div>
@@ -291,21 +291,13 @@
             <div>
                 <div class="text-xs text-gray-500 uppercase">Next Run</div>
                 <div class="text-sm font-medium text-gray-900 whitespace-nowrap">
-                    {% if scheduler.next_run_at %}
-                        {% if scheduler.next_run_at is string %}
-                            {{ scheduler.next_run_at|replace('T', ' ')|replace('+00:00', ' UTC') }}
-                        {% else %}
-                            {{ scheduler.next_run_at.strftime('%Y-%m-%d %H:%M UTC') }}
-                        {% endif %}
-                    {% else %}
-                        --
-                    {% endif %}
+                    {{ scheduler.next_run_at | utc_dt }}
                 </div>
             </div>
             <div>
                 <div class="text-xs text-gray-500 uppercase">Last Run</div>
                 <div class="text-sm font-medium text-gray-900">
-                    {% if scheduler.last_run_at %}{{ scheduler.last_run_at }}{% else %}Never{% endif %}
+                    {% if scheduler.last_run_at %}{{ scheduler.last_run_at | utc_dt }}{% else %}Never{% endif %}
                 </div>
             </div>
             <div>
@@ -341,7 +333,7 @@
                         <tr class="cursor-pointer hover:bg-gray-50" onclick="toggleSyncDetails('sync-details-{{ loop.index }}')">
                             <td class="px-3 py-2 whitespace-nowrap text-gray-500">
                                 <span class="inline-block w-4 text-gray-400 mr-1" id="sync-chevron-{{ loop.index }}">▶</span>
-                                {{ log.started_at.strftime('%m/%d %H:%M') }}
+                                {{ log.started_at | utc_dt('%m/%d %H:%M') }}
                             </td>
                             <td class="px-3 py-2 whitespace-nowrap">
                                 <code class="text-xs bg-gray-100 px-1 rounded">{{ log.user_id[:12] }}{% if log.user_id|length > 12 %}...{% endif %}</code>
@@ -514,7 +506,7 @@
                         </td>
                         <td class="px-4 py-3 text-sm text-gray-500">
                             {% if key.last_used_at %}
-                            {{ key.last_used_at.strftime('%Y-%m-%d %H:%M') }}
+                            {{ key.last_used_at | utc_dt }}
                             {% else %}
                             <span class="text-gray-400">Never</span>
                             {% endif %}
@@ -863,7 +855,7 @@ function toggleSyncDetails(id) {
                 </div>
                 <div class="mt-4 bg-red-50 border border-red-200 rounded-lg p-3">
                     <p class="text-sm text-red-800">
-                        <strong>Warning:</strong> This action cannot be undone. The key will be permanently deactivated. To restore access, you will need to reconnect via OAuth.
+                        <strong>Warning:</strong> This action cannot be undone. The key will be permanently deactivated. To restore API access, create a new API key afterwards.
                     </p>
                 </div>
             </div>

--- a/tests/test_settings_display.py
+++ b/tests/test_settings_display.py
@@ -1,0 +1,100 @@
+"""Settings-page display fixes (issues #69, #73, and #68's server side).
+
+#69: the Sync Configuration card hardcoded "1 hour" / "30 days" whatever
+SYNC_INTERVAL_MINUTES / SYNC_DAYS_LOOKBACK actually were.
+#73: the revoke-key modal claimed restoring access needs OAuth (it needs a
+new API key), and scheduler timestamps rendered raw isoformat.
+#68 (server side): stored-UTC timestamps rendered with no timezone label.
+All timestamp rendering now goes through one `utc_dt` Jinja filter.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from polar_flow_server.app import format_utc
+
+
+class TestUtcDtFilter:
+    def test_datetime_is_labelled_utc(self):
+        value = datetime(2026, 8, 4, 12, 30, tzinfo=UTC)
+        assert format_utc(value) == "2026-08-04 12:30 UTC"
+
+    def test_custom_format(self):
+        value = datetime(2026, 8, 4, 12, 30, tzinfo=UTC)
+        assert format_utc(value, "%m/%d %H:%M") == "08/04 12:30 UTC"
+
+    def test_isoformat_string_is_parsed(self):
+        assert format_utc("2026-08-04T12:30:45.123456+00:00") == "2026-08-04 12:30 UTC"
+
+    def test_none_is_dashes(self):
+        assert format_utc(None) == "--"
+
+    def test_unparseable_string_passes_through(self):
+        assert format_utc("soon") == "soon"
+
+
+async def _login(app_client, admin_account) -> None:
+    response = await app_client.post(
+        "/admin/login",
+        data={"email": admin_account["email"], "password": admin_account["password"]},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+
+
+class TestSettingsPage:
+    @pytest.mark.asyncio
+    async def test_sync_configuration_reflects_settings(
+        self, app_client, admin_account, monkeypatch
+    ):
+        """Tuned env values must show up, not the old hardcoded copy."""
+        from polar_flow_server.core.config import settings
+
+        monkeypatch.setattr(settings, "sync_interval_minutes", 90)
+        monkeypatch.setattr(settings, "sync_days_lookback", 14)
+
+        await _login(app_client, admin_account)
+        response = await app_client.get("/admin/settings")
+        assert response.status_code == 200
+        assert "90 minutes" in response.text
+        assert "14 days" in response.text
+
+    @pytest.mark.asyncio
+    async def test_default_interval_renders_as_hours(self, app_client, admin_account):
+        """60-minute default still reads '1 hour', but derived, not hardcoded."""
+        await _login(app_client, admin_account)
+        response = await app_client.get("/admin/settings")
+        assert response.status_code == 200
+        assert "1 hour" in response.text
+        assert "30 days" in response.text
+
+    @pytest.mark.asyncio
+    async def test_revoke_copy_no_longer_mentions_oauth(self, app_client, admin_account):
+        await _login(app_client, admin_account)
+        response = await app_client.get("/admin/settings")
+        assert response.status_code == 200
+        assert "reconnect via OAuth" not in response.text
+        assert "create a new API key" in response.text
+
+    @pytest.mark.asyncio
+    async def test_sync_log_timestamps_are_utc_labelled(self, app_client, admin_account):
+        """A seeded sync log's started_at renders through the utc_dt filter."""
+        from polar_flow_server.core.database import async_session_maker
+        from polar_flow_server.models.sync_log import SyncLog
+
+        async with async_session_maker() as session:
+            session.add(
+                SyncLog(
+                    user_id="u1",
+                    job_id="job-1",
+                    trigger="manual",
+                    started_at=datetime(2026, 8, 4, 9, 15, tzinfo=UTC),
+                )
+            )
+            await session.commit()
+
+        await _login(app_client, admin_account)
+        response = await app_client.get("/admin/settings")
+        assert response.status_code == 200
+        assert "08/04 09:15 UTC" in response.text


### PR DESCRIPTION
## What

Three display fixes that share the same root (#69, #73, and the server half of #68):

- **New `utc_dt` Jinja filter** — every stored datetime is UTC, but templates `strftime`'d them with no label (users read them as local), the scheduler card printed **raw isoformat with microseconds**, and `next_run_at` needed inline string surgery because it can be string or datetime. One filter now renders them all as `2026-08-04 12:30 UTC` (custom formats supported, handles str/datetime/None). Applied to: dashboard sync badge, sync history, connected-user last sync, API-key last-used, scheduler next/last run.
- **#69:** the Sync Configuration card hardcoded "1 hour" / "30 days" regardless of `SYNC_INTERVAL_MINUTES` / `SYNC_DAYS_LOOKBACK` — contradicting the correct dynamic text 100 lines down the same page. Now derived from settings (60-multiples render as hours).
- **#73:** the revoke-key modal claimed "To restore access, you will need to reconnect via OAuth" — wrong; you create a new API key (the post-revoke partial already said so correctly).

The client-side half of #68 (chart label day-shift) comes in the next PR with #70, since both live in the dashboard JS.

## Testing

New `tests/test_settings_display.py` (9 tests): filter unit tests (datetime/string/None/custom-format/passthrough) plus real-app renders — tuned env values show up ("90 minutes"/"14 days"), defaults still read "1 hour", the OAuth claim is gone, and a seeded sync log renders `08/04 09:15 UTC`.

Fixes #69
Fixes #73