### PR TITLE
Fix chart-label day shift west of UTC; age badges on stale tiles; readiness freshness gate

### DIFF
--- a/src/polar_flow_server/admin/routes.py
+++ b/src/polar_flow_server/admin/routes.py
@@ -264,7 +264,18 @@ def _calculate_recovery_status(
     - readiness_score: 0-100
     - recommendations: list of actionable advice
     - training_advice: what type of training is appropriate today
+
+    Metrics older than 48h are excluded rather than silently blended in —
+    "Today's Readiness" built on last week's sleep is worse than no number.
     """
+    stale_cutoff = date.today() - timedelta(days=2)
+    if sleep and sleep.date < stale_cutoff:
+        sleep = None
+    if recharge and recharge.date < stale_cutoff:
+        recharge = None
+    if cardio and cardio.date < stale_cutoff:
+        cardio = None
+
     recommendations: list[str] = []
     factors: list[float] = []
 
@@ -868,11 +879,27 @@ async def admin_dashboard(
         patterns_result = await session.execute(patterns_stmt)
         user_patterns = list(patterns_result.scalars().all())
 
+    # Record dates feeding the stat tiles' age badges (issue #70): the tiles
+    # show "latest" values, which can silently be days old after a sync gap.
+    tile_dates = {
+        "hrv": latest_recharge.date if latest_recharge else None,
+        "sleep": recent_sleep[0].date if recent_sleep else None,
+        "breathing": breathing_record.date if breathing_record else None,
+        "alertness": latest_alertness.period_start_time.date() if latest_alertness else None,
+        "resting_hr": resting_hr_record.date if resting_hr_record else None,
+        "daily_hr": latest_hr.date if latest_hr else None,
+        "spo2": latest_spo2.test_time.date() if latest_spo2 else None,
+        "skin_temp": latest_skin_temp.sleep_date if latest_skin_temp else None,
+        "activity": latest_activity.date if latest_activity else None,
+        "cardio": latest_cardio.date if latest_cardio else None,
+    }
+
     return Template(
         template_name="admin/dashboard.html",
         context={
             # Latest data
             "recent_sleep": recent_sleep,
+            "tile_dates": tile_dates,
             "recent_recharge": recent_recharge,
             "latest_hrv": latest_hrv,
             "latest_resting_hr": latest_resting_hr,

--- a/src/polar_flow_server/app.py
+++ b/src/polar_flow_server/app.py
@@ -2,7 +2,7 @@
 
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 import structlog
@@ -52,8 +52,19 @@ def format_utc(value: datetime | str | None, fmt: str = "%Y-%m-%d %H:%M") -> str
     return value.strftime(fmt) + " UTC"
 
 
+def days_old(value: Any) -> int:
+    """Jinja filter: whole days between a stored date/datetime and today (UTC).
+
+    Feeds the dashboard tiles' "Nd ago" staleness badges (issue #70).
+    """
+    if isinstance(value, datetime):
+        value = value.date()
+    return (datetime.now(UTC).date() - value).days
+
+
 def _register_template_filters(engine: JinjaTemplateEngine) -> None:
     engine.engine.filters["utc_dt"] = format_utc
+    engine.engine.filters["days_old"] = days_old
 
 
 # Configure structured logging

--- a/src/polar_flow_server/app.py
+++ b/src/polar_flow_server/app.py
@@ -2,7 +2,7 @@
 
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from pathlib import Path
 
 import structlog
@@ -52,7 +52,7 @@ def format_utc(value: datetime | str | None, fmt: str = "%Y-%m-%d %H:%M") -> str
     return value.strftime(fmt) + " UTC"
 
 
-def days_old(value: Any) -> int:
+def days_old(value: date | datetime) -> int:
     """Jinja filter: whole days between a stored date/datetime and today (UTC).
 
     Feeds the dashboard tiles' "Nd ago" staleness badges (issue #70).

--- a/src/polar_flow_server/templates/admin/dashboard.html
+++ b/src/polar_flow_server/templates/admin/dashboard.html
@@ -3,6 +3,12 @@
 {% block title %}Dashboard - polar-flow-server{% endblock %}
 
 {% block content %}
+{% macro age_badge(d) -%}
+{%- if d is not none -%}{%- set age = d | days_old -%}
+{%- if age >= 1 -%}
+<div class="text-[10px] mt-1 font-medium {% if age >= 3 %}text-amber-600{% else %}text-gray-400{% endif %}">{{ age }}d ago</div>
+{%- endif -%}{%- endif -%}
+{%- endmacro %}
 <div class="mb-8 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
     <div class="min-w-0">
         <h1 class="text-3xl font-bold text-gray-900">Dashboard</h1>
@@ -200,6 +206,7 @@
                 <div class="text-indigo-900 text-2xl font-bold mt-1">
                     {% if latest_hrv %}{{ latest_hrv|round(0) }}<span class="text-sm font-normal ml-1">ms</span>{% else %}--{% endif %}
                 </div>
+                {{ age_badge(tile_dates.hrv) }}
             </div>
         </div>
 
@@ -210,6 +217,7 @@
                 <div class="text-violet-900 text-2xl font-bold mt-1">
                     {% if recent_sleep and recent_sleep[0].sleep_score %}{{ recent_sleep[0].sleep_score }}<span class="text-sm font-normal ml-1">/100</span>{% else %}--{% endif %}
                 </div>
+                {{ age_badge(tile_dates.sleep) }}
             </div>
         </div>
 
@@ -220,6 +228,7 @@
                 <div class="text-blue-900 text-2xl font-bold mt-1">
                     {% if latest_breathing_rate %}{{ latest_breathing_rate|round(1) }}<span class="text-sm font-normal ml-1">/min</span>{% else %}--{% endif %}
                 </div>
+                {{ age_badge(tile_dates.breathing) }}
             </div>
         </div>
 
@@ -230,6 +239,7 @@
                 <div class="text-sky-900 text-2xl font-bold mt-1">
                     {% if latest_alertness %}{{ latest_alertness.grade|round(1) }}<span class="text-sm font-normal ml-1">/10</span>{% else %}--{% endif %}
                 </div>
+                {{ age_badge(tile_dates.alertness) }}
             </div>
         </div>
     </div>
@@ -243,6 +253,7 @@
                 <div class="text-rose-900 text-2xl font-bold mt-1">
                     {% if latest_resting_hr %}{{ latest_resting_hr|round(0) }}<span class="text-sm font-normal ml-1">bpm</span>{% else %}--{% endif %}
                 </div>
+                {{ age_badge(tile_dates.resting_hr) }}
             </div>
         </div>
 
@@ -253,6 +264,7 @@
                 <div class="text-red-900 text-2xl font-bold mt-1">
                     {% if latest_hr and latest_hr.hr_avg %}{{ latest_hr.hr_avg }}<span class="text-sm font-normal ml-1">bpm</span>{% else %}--{% endif %}
                 </div>
+                {{ age_badge(tile_dates.daily_hr) }}
             </div>
         </div>
 
@@ -263,6 +275,7 @@
                 <div class="text-fuchsia-900 text-2xl font-bold mt-1">
                     {% if latest_spo2 %}{{ latest_spo2.blood_oxygen_percent }}<span class="text-sm font-normal ml-1">%</span>{% else %}--{% endif %}
                 </div>
+                {{ age_badge(tile_dates.spo2) }}
             </div>
         </div>
 
@@ -275,6 +288,7 @@
                         {% if latest_skin_temp.deviation_from_baseline >= 0 %}+{% endif %}{{ latest_skin_temp.deviation_from_baseline|round(1) }}<span class="text-sm font-normal ml-1">°C</span>
                     {% else %}--{% endif %}
                 </div>
+                {{ age_badge(tile_dates.skin_temp) }}
             </div>
         </div>
     </div>
@@ -288,6 +302,7 @@
                 <div class="text-emerald-900 text-2xl font-bold mt-1">
                     {% if latest_activity and latest_activity.steps %}{{ "{:,}".format(latest_activity.steps) }}{% else %}--{% endif %}
                 </div>
+                {{ age_badge(tile_dates.activity) }}
             </div>
         </div>
 
@@ -298,6 +313,7 @@
                 <div class="text-green-900 text-2xl font-bold mt-1">
                     {% if latest_activity and latest_activity.calories_active %}{{ "{:,}".format(latest_activity.calories_active) }}{% else %}--{% endif %}
                 </div>
+                {{ age_badge(tile_dates.activity) }}
             </div>
         </div>
 
@@ -308,6 +324,7 @@
                 <div class="text-teal-900 text-2xl font-bold mt-1">
                     {% if latest_cardio and latest_cardio.strain %}{{ latest_cardio.strain|round(0) }}{% else %}--{% endif %}
                 </div>
+                {{ age_badge(tile_dates.cardio) }}
             </div>
         </div>
 
@@ -318,6 +335,7 @@
                 <div class="text-lime-900 text-2xl font-bold mt-1">
                     {% if latest_cardio and latest_cardio.cardio_load_ratio and latest_cardio.cardio_load_ratio > 0 %}{{ latest_cardio.cardio_load_ratio|round(2) }}{% else %}--{% endif %}
                 </div>
+                {{ age_badge(tile_dates.cardio) }}
             </div>
         </div>
     </div>
@@ -995,10 +1013,12 @@ const commonOptions = {
     }
 };
 
-// Format date labels for display
+// Format date labels for display. Date-only strings parse as UTC midnight
+// via new Date(str), so users west of UTC saw every label a day early —
+// parse the parts as a local date instead, and use the browser locale.
 function formatDateLabel(dateStr) {
-    const d = new Date(dateStr);
-    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    const [y, m, d] = dateStr.split('-').map(Number);
+    return new Date(y, m - 1, d).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 }
 
 // Create custom tooltip callback

--- a/tests/test_dashboard_freshness.py
+++ b/tests/test_dashboard_freshness.py
@@ -1,0 +1,127 @@
+"""Stale-data handling on the dashboard (issues #70 and #68's client side).
+
+#70: stat tiles show `latest_*` records — after a sync gap they presented
+4-day-old numbers as if they were today's, and "Today's Readiness" blended
+whatever was latest per metric regardless of freshness. Tiles now carry an
+"Nd ago" badge and the readiness calculation excludes metrics older than 48h.
+
+#68 (client side): formatDateLabel parsed date-only strings as UTC midnight,
+shifting every chart label a day west of UTC. Regression-guarded here; the
+behavioural fix lives in the template JS.
+"""
+
+from datetime import UTC, date, datetime, timedelta
+
+import pytest
+
+from polar_flow_server.app import days_old
+
+
+class TestDaysOldFilter:
+    def test_today_is_zero(self):
+        assert days_old(date.today()) == 0
+
+    def test_dates_and_datetimes(self):
+        assert days_old(date.today() - timedelta(days=3)) == 3
+        assert days_old(datetime.now(UTC) - timedelta(days=2)) == 2
+
+
+class TestReadinessFreshnessGate:
+    def _sleep(self, days_ago: int, score: int = 30):
+        from polar_flow_server.models.sleep import Sleep
+
+        return Sleep(
+            id=f"s-{days_ago}",
+            user_id="u",
+            date=date.today() - timedelta(days=days_ago),
+            sleep_score=score,
+        )
+
+    def test_fresh_sleep_counts(self):
+        from polar_flow_server.admin.routes import _calculate_recovery_status
+
+        status = _calculate_recovery_status(
+            sleep=self._sleep(0, score=30), recharge=None, cardio=None
+        )
+        assert any("Poor sleep" in r for r in status["recommendations"])
+
+    def test_stale_sleep_is_excluded(self):
+        """Four-day-old poor sleep must not drive today's advice."""
+        from polar_flow_server.admin.routes import _calculate_recovery_status
+
+        status = _calculate_recovery_status(
+            sleep=self._sleep(4, score=30), recharge=None, cardio=None
+        )
+        assert not any("Poor sleep" in r for r in status["recommendations"])
+
+    def test_two_day_old_sleep_still_counts(self):
+        """48h is the cutoff — within it, data participates."""
+        from polar_flow_server.admin.routes import _calculate_recovery_status
+
+        status = _calculate_recovery_status(
+            sleep=self._sleep(1, score=30), recharge=None, cardio=None
+        )
+        assert any("Poor sleep" in r for r in status["recommendations"])
+
+
+async def _login(app_client, admin_account) -> None:
+    response = await app_client.post(
+        "/admin/login",
+        data={"email": admin_account["email"], "password": admin_account["password"]},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+
+
+class TestTileAgeBadges:
+    @pytest.mark.asyncio
+    async def test_stale_tile_shows_age_badge(self, app_client, admin_account):
+        from polar_flow_server.core.database import async_session_maker
+        from polar_flow_server.models.activity import Activity
+
+        async with async_session_maker() as session:
+            session.add(
+                Activity(
+                    id="a-old",
+                    user_id="u",
+                    date=date.today() - timedelta(days=4),
+                    steps=9999,
+                )
+            )
+            await session.commit()
+
+        await _login(app_client, admin_account)
+        response = await app_client.get("/admin/dashboard")
+        assert response.status_code == 200
+        assert "9,999" in response.text
+        assert "4d ago" in response.text
+
+    @pytest.mark.asyncio
+    async def test_todays_data_has_no_badge(self, app_client, admin_account):
+        from polar_flow_server.core.database import async_session_maker
+        from polar_flow_server.models.activity import Activity
+
+        async with async_session_maker() as session:
+            session.add(Activity(id="a-now", user_id="u", date=date.today(), steps=1234))
+            await session.commit()
+
+        await _login(app_client, admin_account)
+        response = await app_client.get("/admin/dashboard")
+        assert response.status_code == 200
+        assert "1,234" in response.text
+        assert "d ago" not in response.text
+
+
+class TestChartLabelParsing:
+    def test_no_utc_midnight_date_parsing_in_template(self):
+        """new Date('YYYY-MM-DD') parses as UTC midnight — the day-shift bug.
+        The label formatter must build the date from parts instead."""
+        from pathlib import Path
+
+        import polar_flow_server
+
+        template = (
+            Path(polar_flow_server.__file__).parent / "templates" / "admin" / "dashboard.html"
+        ).read_text()
+        assert "new Date(dateStr)" not in template
+        assert "toLocaleDateString('en-US'" not in template


### PR DESCRIPTION
**Stacked on #108** (shares the Jinja-filter plumbing) — merge that first; this diff includes it until then.

## What

- **#68 (client side):** `formatDateLabel` parsed `new Date('2026-07-15')` — UTC midnight — so users west of UTC saw every chart label one day earlier than the tables next to them. Now builds the date from parts (local) and uses the browser locale instead of hardcoded `en-US`.
- **#70:** the overview tiles show `latest_*` records — after a sync gap they presented 4-day-old numbers as today's, with no hint. Every stat tile (all 12) now shows an **"Nd ago"** badge when its record isn't from today (grey, turning amber at 3 days), via a new `days_old` filter + record-date map from the route. And **"Today's Readiness"** now excludes metrics older than 48h from the calculation instead of silently blending them — advice built on last week's sleep is worse than no advice.

## Testing

New `tests/test_dashboard_freshness.py` (8 tests): `days_old` units; readiness gate (fresh poor sleep drives advice, 4-day-old poor sleep doesn't, 1-day-old still does); real-app renders (stale activity shows `4d ago` badge, today's data shows none); regression guard that the UTC-midnight parse can't come back.

Fixes #68
Fixes #70