### PR TITLE
Fix stale documentation and remove the dead api_key_guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Self-hosted health analytics server for Polar devices. Syncs data from Polar AccessLink API (9+ endpoints) to PostgreSQL and provides an HTMX-powered admin dashboard plus REST API.
+Self-hosted health analytics server for Polar devices. Syncs data from Polar AccessLink API (13 endpoints incl. biosensing) to PostgreSQL and provides an HTMX-powered admin dashboard plus REST API.
 
 ## Development Commands
 
@@ -92,7 +92,7 @@ class SleepTransformer:
 
 **Admin Auth**: Session-based authentication for admin panel (separate from API key auth). First-run flow: setup account -> OAuth credentials -> connect Polar.
 
-**API Auth**: Optional API key via `X-API-Key` header. Controlled by `API_KEY` env var. If not set, data endpoints are open.
+**API Auth**: An API key is ALWAYS required on data endpoints via the `X-API-Key` header (health data is never public). Per-user keys are created from the admin dashboard / OAuth flow; the optional `API_KEY` env var adds a master key for backend use. Guard: `per_user_api_key_guard` in `core/auth.py`.
 
 ### Database
 

--- a/README.md
+++ b/README.md
@@ -69,17 +69,21 @@ The server syncs data every hour automatically.
 
 ## Dashboard
 
-The admin panel at `/admin/dashboard` shows:
+The admin panel at `/admin/dashboard` is organised into tabs (with a
+floating tab bar on mobile):
 
-- **Key Metrics** - HRV, Heart Rate, Training Strain, Alertness, Sleep Score
-- **API Keys** - Manage per-user API keys with rate limit tracking
-- **Record Counts** - All 9 data types with totals
-- **Recent Sleep** - Last 7 days with scores
-- **Nightly Recharge** - HRV, ANS charge, recovery status
-- **Training Load** - Strain, tolerance, load ratio
-- **Continuous HR** - Daily min/avg/max heart rate
+- **Overview** - stat tiles (HRV, resting HR, SpO2, skin temp, steps, strain,
+  sleep score, alertness...), Today's Readiness recommendations, and
+  "Today at a Glance" mini-charts (sleep stages, heart rate, steps)
+- **Trends & Baselines** - personal baselines and detected patterns
+- **Sleep** - sleep score and stage-duration charts
+- **Heart Rate** - daily HR, HRV and ANS charge charts, biosensing panel
+- **Training Load** - activity and cardio load charts
 
-## Data Synced (9 Endpoints)
+Charts have a selectable 7/14/30-day range and CSV export. API keys are
+managed from the settings page, with rate limit tracking.
+
+## Data Synced (13 Endpoints)
 
 | Endpoint | Data |
 |----------|------|
@@ -92,6 +96,10 @@ The admin panel at `/admin/dashboard` shows:
 | **SleepWise Bedtime** | Optimal sleep timing recommendations |
 | **Activity Samples** | Minute-by-minute step data |
 | **Continuous HR** | All-day heart rate (5-min intervals) |
+| **SpO2** | Blood oxygen tests (compatible devices) |
+| **ECG** | Electrocardiogram tests (compatible devices) |
+| **Body Temperature** | Continuous body temperature |
+| **Skin Temperature** | Nightly skin temperature with baseline deviation |
 
 ## Configuration
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,10 +9,10 @@ Self-hosted health analytics server for Polar devices.
 Polar devices collect health data: sleep, HRV, activity, exercises. The Polar API provides access to this data, but only for the last 28-30 days. This server:
 
 1. Syncs data from Polar API automatically
-2. Stores everything in a local database (DuckDB or PostgreSQL)
+2. Stores everything in a local PostgreSQL database
 3. Runs analytics (HRV baselines, recovery scores, sleep debt)
 4. Exposes REST API for dashboards and integrations
-5. Provides MCP server for Claude Desktop integration
+5. Exposes the data for integrations (an MCP server for AI assistants is planned - issue #80)
 
 ## Features
 
@@ -34,7 +34,7 @@ Polar devices collect health data: sleep, HRV, activity, exercises. The Polar AP
 - Unified insights API with natural language observations
 
 **Deployment:**
-- Self-hosted mode: Single user, DuckDB, Docker
+- Self-hosted mode: Single user, PostgreSQL, Docker
 - SaaS mode: Multi-user, PostgreSQL, Laravel integration
 
 ## Architecture
@@ -52,7 +52,7 @@ flowchart LR
 Python data analytics engine:
 - Litestar (async web framework)
 - SQLAlchemy 2.0 (async ORM)
-- DuckDB (self-hosted) or PostgreSQL (SaaS)
+- PostgreSQL (asyncpg)
 - Polars (data processing)
 - Strict type checking with mypy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ disallow_untyped_defs = true
 plugins = ["pydantic.mypy"]
 
 [[tool.mypy.overrides]]
-module = ["apscheduler.*", "duckdb_engine.*"]
+module = ["apscheduler.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/src/polar_flow_server/core/auth.py
+++ b/src/polar_flow_server/core/auth.py
@@ -1,7 +1,7 @@
 """API key authentication for service-to-service requests.
 
 Supports two authentication modes:
-1. Simple mode: Single API key from config (API_KEY env var)
+1. Master key mode: single API key from config (API_KEY env var)
 2. Per-user mode: User-scoped keys from database with rate limiting
 """
 
@@ -79,24 +79,6 @@ async def validate_api_key(key: str, session: AsyncSession) -> APIKey | None:
     return api_key
 
 
-async def validate_simple_api_key(key: str) -> bool:
-    """Validate API key against simple config-based key.
-
-    For self-hosted single-key deployments where database lookup
-    is overkill. Uses constant-time comparison to prevent timing attacks.
-
-    Args:
-        key: The API key to validate
-
-    Returns:
-        True if valid, False otherwise
-    """
-    if not settings.api_key:
-        return False
-
-    return secrets.compare_digest(key, settings.api_key)
-
-
 def _extract_api_key(connection: ASGIConnection[Any, Any, Any, Any]) -> str | None:
     """Extract API key from request headers.
 
@@ -157,45 +139,6 @@ async def _check_rate_limit(api_key: APIKey, session: AsyncSession) -> tuple[boo
     await session.commit()
 
     return True, rate_limit_info
-
-
-async def api_key_guard(
-    connection: ASGIConnection[Any, Any, Any, Any], _: BaseRouteHandler
-) -> None:
-    """Litestar guard that validates API key from request header.
-
-    Validates against config-based master key or database keys.
-
-    Args:
-        connection: The ASGI connection
-        _: The route handler (unused)
-
-    Raises:
-        NotAuthorizedException: If API key is missing or invalid
-    """
-    # Extract API key from headers
-    api_key = _extract_api_key(connection)
-
-    if not api_key:
-        logger.warning("API request without authentication")
-        raise NotAuthorizedException("Missing API key. Use X-API-Key header.")
-
-    # Validate the key
-    is_valid = await validate_simple_api_key(api_key)
-
-    # If config key didn't match, try database
-    if not is_valid:
-        from polar_flow_server.core.database import async_session_maker
-
-        async with async_session_maker() as session:
-            api_key_model = await validate_api_key(api_key, session)
-            is_valid = api_key_model is not None
-
-    if not is_valid:
-        logger.warning("Invalid API key attempted")
-        raise NotAuthorizedException("Invalid API key")
-
-    logger.debug("API key validated successfully")
 
 
 async def per_user_api_key_guard(

--- a/tests/test_docs_accuracy.py
+++ b/tests/test_docs_accuracy.py
@@ -1,0 +1,33 @@
+"""Guards against the stale documentation claims fixed in issue #88.
+
+Docs drift silently; these pin the claims that were actively wrong: CLAUDE.md
+said data endpoints are open without API_KEY (false since the per-user guard
+landed), the superseded api_key_guard lingered as dead code, and docs claimed
+DuckDB support and a shipped MCP server.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+
+def test_claude_md_does_not_claim_open_endpoints():
+    text = (ROOT / "CLAUDE.md").read_text()
+    assert "data endpoints are open" not in text
+    assert "ALWAYS required" in text
+
+
+def test_dead_api_key_guard_is_gone():
+    import polar_flow_server.core.auth as auth
+
+    assert not hasattr(auth, "api_key_guard")
+    assert not hasattr(auth, "validate_simple_api_key")
+    assert hasattr(auth, "per_user_api_key_guard")
+
+
+def test_docs_do_not_claim_duckdb_or_shipped_mcp():
+    for doc in ("docs/index.md", "README.md"):
+        text = (ROOT / doc).read_text()
+        assert "DuckDB" not in text, doc
+    index = (ROOT / "docs" / "index.md").read_text()
+    assert "planned" in index.split("MCP")[1][:80].lower()


### PR DESCRIPTION
## What (#88)

- **CLAUDE.md** claimed "If `API_KEY` is not set, data endpoints are open" — **false** since the per-user guard landed (`core/auth.py`: the key is ALWAYS required). Corrected to describe the real model: per-user keys + optional master key, `per_user_api_key_guard`.
- **Dead code:** the superseded `api_key_guard` and its `validate_simple_api_key` helper had zero callers (the live guard handles the master key itself). Removed, module docstring updated.
- **README:** described the pre-tab dashboard and "9 endpoints" — rewritten for the tabbed layout (Overview / Trends / Sleep / Heart Rate / Training Load, Today at a Glance, chart ranges + CSV export) and the endpoint table now lists all **13** synced endpoints including the four biosensing ones.
- **docs/index.md:** claimed DuckDB support (nothing in the code supports it — also dropped the leftover `duckdb_engine` mypy override) and a *shipped* MCP server (that's #80, still planned). Both corrected.

## Testing

`tests/test_docs_accuracy.py` (3 tests) pins the corrected claims — the open-endpoints wording, the dead guard's absence, and the DuckDB/MCP claims — so they can't silently rot again. API-key test suite still green (27 passed).

Fixes #88