### PR TITLE
MCP sync tools + docs: trigger/poll, client setup guide, truthful claims (#80)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,11 @@ api/
 admin/
   routes.py         # Admin dashboard, OAuth flow, settings
   auth.py           # Admin user authentication (session-based)
+mcp_server/
+  server.py         # MCP server factory (tool registration = wire order)
+  tools.py          # MCP tool implementations
+  asgi.py           # /mcp Litestar mount with API-key auth
+  context.py        # Request-scoped key scope for tools
 templates/          # Jinja2 templates for admin UI
 ```
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,24 @@ managed from the settings page, with rate limit tracking.
 | **Body Temperature** | Continuous body temperature |
 | **Skin Temperature** | Nightly skin temperature with baseline deviation |
 
+## MCP Server (AI Assistants)
+
+A built-in [Model Context Protocol](https://modelcontextprotocol.io) server
+(protocol revision 2026-07-28, streamable HTTP) lets AI assistants query your
+health data directly - "how has my sleep trended vs my baseline?", "should I
+train hard today?". It runs inside the main server at `/mcp`, authenticated
+with the same API keys as the REST API:
+
+```bash
+claude mcp add polar-health https://your-server.example.com/mcp \
+  --transport http \
+  --header "X-API-Key: pfk_your_key_here"
+```
+
+Ten tools cover insights, sleep, recovery, activity, workouts, biosensing
+streams, personal baselines, patterns/anomalies, and sync control. See
+[docs/mcp-server.md](docs/mcp-server.md).
+
 ## Configuration
 
 ### Required Environment Variables

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Polar devices collect health data: sleep, HRV, activity, exercises. The Polar AP
 2. Stores everything in a local PostgreSQL database
 3. Runs analytics (HRV baselines, recovery scores, sleep debt)
 4. Exposes REST API for dashboards and integrations
-5. Exposes the data for integrations (an MCP server for AI assistants is planned - issue #80)
+5. Ships a built-in [MCP server](mcp-server.md) so AI assistants can query and reason over the data
 
 ## Features
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,90 @@
+# MCP Server
+
+polar-flow-server ships a built-in [Model Context Protocol](https://modelcontextprotocol.io)
+server, so any MCP-capable AI assistant (Claude Code, Claude Desktop, and a
+growing list of others) can query your health data and reason over it:
+
+> "How has my sleep trended this month compared to my baseline?"
+> "Should I train hard today?"
+> "Any signs I'm getting ill?"
+
+The server speaks MCP protocol revision **2026-07-28** (stateless streamable
+HTTP) and still serves older 2025-era clients. It runs **inside** the main
+server process — no sidecar, nothing extra to deploy — at:
+
+```
+https://your-server.example.com/mcp
+```
+
+## Authentication
+
+The MCP endpoint uses the same API keys as the REST API, sent as an
+`X-API-Key` header or `Authorization: Bearer` token. Create a key in the
+admin dashboard (Settings → API Keys).
+
+Scoping is identical to the REST API and enforced before any MCP protocol
+handling:
+
+- **User-scoped keys** can only ever read their own user's data. Tools need
+  no `user_id` argument — the key decides.
+- **Service-level keys** may pass an explicit `user_id` tool argument on
+  multi-user installs, and default to the connected user otherwise.
+
+Rate limits are shared with the REST API (per key, per hour).
+
+## Connecting a client
+
+### Claude Code
+
+```bash
+claude mcp add polar-health https://your-server.example.com/mcp \
+  --transport http \
+  --header "X-API-Key: pfk_your_key_here"
+```
+
+### Claude Desktop / other clients
+
+Add a custom connector / remote MCP server with URL
+`https://your-server.example.com/mcp`. If the client supports custom
+headers, set `X-API-Key`; if it only supports bearer auth, use your API key
+as the bearer token.
+
+### Verify
+
+Ask the assistant something like *"use polar-health to summarize how I'm
+doing"* — it should call `get_health_insights` and answer with your real
+numbers.
+
+## Tools
+
+| Tool | What it returns |
+|------|-----------------|
+| `get_health_insights` | The one-shot assessment: current metrics vs personal baselines, trends, patterns, anomalies, plain-language observations and suggestions |
+| `get_sleep` | Nightly sleep records: score, stage breakdown, overnight HRV/HR/breathing/skin-temp |
+| `get_recovery` | Nightly recharge (ANS charge, HRV) and cardio load (strain vs tolerance) |
+| `get_activity` | Daily steps, calories, distance, active minutes, activity score |
+| `get_exercises` | Workout history; pass `exercise_id` for one workout's full detail |
+| `get_biosensing` | One stream per call via `metric`: `spo2`, `ecg`, `body_temperature`, `skin_temperature`, `heart_rate`, `alertness`, `bedtime` |
+| `get_baselines` | Personal rolling averages and IQR anomaly bounds per metric |
+| `get_patterns` | Stored pattern analyses (sleep-HRV correlation, overtraining risk, trends) plus a live anomaly check |
+| `trigger_sync` | Starts a background sync from Polar (honours the in-progress guard and Polar rate-limit cooldowns) |
+| `get_sync_status` | Whether a sync is running, the last sync's audit record, current Polar rate-limit state |
+
+Tool descriptions are written for the model — units, semantics, and when to
+use which tool — so assistants generally pick sensibly without prompting.
+
+The tool list order is stable and `tools/list` carries a one-hour cache
+hint (`ttlMs`), so client-side prompt caches stay warm across calls.
+
+## Notes for operators
+
+- `/mcp` sits behind the same security-header middleware as the rest of the
+  app, and is excluded from CSRF (it is API-key authenticated JSON-RPC, not
+  a browser form target).
+- Unauthenticated requests are rejected at the HTTP layer (401/429) without
+  touching the MCP protocol stack.
+- The endpoint works offline/on a LAN like the rest of the server — there
+  are no third-party calls involved.
+- Long-running sync is exposed as trigger + poll (`trigger_sync` →
+  `get_sync_status`). When the MCP Tasks extension (SEP-2663) lands in the
+  official SDK, sync will adopt it.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ nav:
   - Integration Guide: integration.md
   - Architecture: architecture.md
   - API Reference: api/overview.md
+  - MCP Server: mcp-server.md
   - ADRs:
     - Per-User API Keys: adr/001-per-user-api-keys.md
 

--- a/src/polar_flow_server/mcp_server/server.py
+++ b/src/polar_flow_server/mcp_server/server.py
@@ -38,6 +38,8 @@ _TOOLS = (
     tools.get_biosensing,
     tools.get_baselines,
     tools.get_patterns,
+    tools.trigger_sync,
+    tools.get_sync_status,
 )
 
 

--- a/src/polar_flow_server/mcp_server/tools.py
+++ b/src/polar_flow_server/mcp_server/tools.py
@@ -10,6 +10,7 @@ Tool registration order (see ``server.py``) is the order clients see in
 prompt caches warm.
 """
 
+import asyncio
 from datetime import date, timedelta
 from typing import Annotated, Any, Literal
 
@@ -435,6 +436,138 @@ async def get_patterns(user_id: UserIdParam = None) -> dict[str, Any]:
         "anomaly_count": len(anomalies),
         "anomalies": anomalies,
     }
+
+
+# Strong references to in-flight background syncs so they aren't GC'd
+# mid-run (asyncio only holds weak references to tasks).
+_background_syncs: set[asyncio.Task[None]] = set()
+
+
+async def trigger_sync(user_id: UserIdParam = None) -> dict[str, Any]:
+    """Start a data sync from the Polar cloud for the user.
+
+    Kicks off a full sync (all 13 endpoint types) in the background using
+    the server's stored Polar credentials, then returns immediately - poll
+    get_sync_status to watch it finish (typically well under a minute).
+    Only one sync runs per user at a time, and the server honours Polar's
+    rate-limit cooldowns: the response status is "started",
+    "already_running", or "rate_limited" (with retry_after_seconds). Data
+    also syncs automatically on a schedule, so only trigger a sync when the
+    user asks for fresh data or get_sync_status shows stale data.
+    """
+    uid = await resolve_scoped_user_id(user_id)
+
+    from polar_flow_server.core.database import async_session_maker
+    from polar_flow_server.core.security import token_encryption
+    from polar_flow_server.models.user import User
+    from polar_flow_server.services.sync_guard import is_syncing
+    from polar_flow_server.services.sync_orchestrator import shared_rate_limit_tracker
+
+    if is_syncing(uid):
+        return {"status": "already_running", "user_id": uid}
+
+    if not shared_rate_limit_tracker.can_sync_now():
+        return {
+            "status": "rate_limited",
+            "user_id": uid,
+            "retry_after_seconds": shared_rate_limit_tracker.get_wait_time_seconds(),
+        }
+
+    async with async_session_maker() as session:
+        result = await session.execute(
+            select(User).where(User.polar_user_id == uid, User.is_active == True)  # noqa: E712
+        )
+        user = result.scalar_one_or_none()
+        if user is None:
+            raise ValueError(f"No connected Polar user '{uid}' to sync")
+        polar_token = token_encryption.decrypt(user.access_token_encrypted)
+
+    task = asyncio.create_task(_run_background_sync(uid, polar_token))
+    _background_syncs.add(task)
+    task.add_done_callback(_background_syncs.discard)
+
+    return {
+        "status": "started",
+        "user_id": uid,
+        "message": "Sync running in the background; poll get_sync_status for the result.",
+    }
+
+
+async def get_sync_status(user_id: UserIdParam = None) -> dict[str, Any]:
+    """Get the user's sync state: is one running, the last result, freshness.
+
+    `currently_syncing` is live; `last_sync` is the most recent sync's audit
+    record (status success/partial/failed/skipped, what triggered it, start
+    and end times, per-endpoint record counts, and error details if any);
+    `polar_rate_limit` reports the shared Polar API budget including any
+    active cooldown (rate_limited_until). Check this after trigger_sync, or
+    first whenever other tools return surprisingly old data.
+    """
+    uid = await resolve_scoped_user_id(user_id)
+
+    from polar_flow_server.core.database import async_session_maker
+    from polar_flow_server.models.sync_log import SyncLog
+    from polar_flow_server.services.sync_guard import is_syncing
+    from polar_flow_server.services.sync_orchestrator import shared_rate_limit_tracker
+
+    async with async_session_maker() as session:
+        result = await session.execute(
+            select(SyncLog)
+            .where(SyncLog.user_id == uid)
+            .order_by(SyncLog.started_at.desc())
+            .limit(1)
+        )
+        log = result.scalar_one_or_none()
+
+    last_sync = None
+    if log is not None:
+        last_sync = {
+            "status": log.status,
+            "trigger": log.trigger,
+            "started_at": log.started_at.isoformat() if log.started_at else None,
+            "completed_at": log.completed_at.isoformat() if log.completed_at else None,
+            "duration_ms": log.duration_ms,
+            "records_synced": log.records_synced,
+            "api_calls_made": log.api_calls_made,
+            "error_type": log.error_type,
+            "error_message": log.error_message,
+        }
+
+    return {
+        "user_id": uid,
+        "currently_syncing": is_syncing(uid),
+        "last_sync": last_sync,
+        "polar_rate_limit": shared_rate_limit_tracker.to_dict(),
+    }
+
+
+async def _run_background_sync(uid: str, polar_token: str) -> None:
+    """Run one orchestrated sync in the background.
+
+    The orchestrator writes its own SyncLog audit trail (including
+    failures), so this only needs to absorb pre-log races and log the
+    truly unexpected.
+    """
+    import structlog
+
+    from polar_flow_server.core.database import async_session_maker
+    from polar_flow_server.models.sync_log import SyncTrigger
+    from polar_flow_server.services.sync_guard import SyncInProgressError
+    from polar_flow_server.services.sync_orchestrator import SyncOrchestrator
+
+    try:
+        async with async_session_maker() as session:
+            await SyncOrchestrator(session).sync_user(
+                user_id=uid,
+                polar_token=polar_token,
+                trigger=SyncTrigger.MANUAL,
+            )
+    except SyncInProgressError:
+        # Lost a race with the scheduler between our check and the slot
+        # grab - the other sync is doing the same work, nothing to do.
+        pass
+    except Exception:
+        structlog.get_logger().exception("MCP-triggered sync failed before logging", user_id=uid)
 
 
 async def _query_biosensing(

--- a/tests/test_docs_accuracy.py
+++ b/tests/test_docs_accuracy.py
@@ -25,9 +25,16 @@ def test_dead_api_key_guard_is_gone():
     assert hasattr(auth, "per_user_api_key_guard")
 
 
-def test_docs_do_not_claim_duckdb_or_shipped_mcp():
+def test_docs_do_not_claim_duckdb():
     for doc in ("docs/index.md", "README.md"):
         text = (ROOT / doc).read_text()
         assert "DuckDB" not in text, doc
+
+
+def test_mcp_claims_match_reality():
+    """The MCP server ships now (#80) - docs must say so, not 'planned'."""
     index = (ROOT / "docs" / "index.md").read_text()
-    assert "planned" in index.split("MCP")[1][:80].lower()
+    assert "planned" not in index.split("MCP")[1][:80].lower()
+    assert (ROOT / "docs" / "mcp-server.md").exists()
+    readme = (ROOT / "README.md").read_text()
+    assert "/mcp" in readme

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -144,6 +144,8 @@ async def test_tools_list_names_and_order(app_client) -> None:
         "get_biosensing",
         "get_baselines",
         "get_patterns",
+        "trigger_sync",
+        "get_sync_status",
     ]
     sleep_tool = tools.tools[1]
     assert "sleep" in (sleep_tool.description or "").lower()
@@ -398,6 +400,125 @@ async def test_get_baselines_and_patterns_after_analysis(app_client) -> None:
     pattern_names = {p["pattern_name"] for p in payload["patterns"]}
     assert "hrv_trend" in pattern_names
     assert "anomaly_count" in payload
+
+
+# =============================================================================
+# Sync tools: trigger (background) + status (poll)
+# =============================================================================
+
+
+async def _seed_syncable_user(polar_user_id: str = "mcp-user") -> str:
+    """User whose stored token actually decrypts (trigger_sync needs it)."""
+    from polar_flow_server.core.security import token_encryption
+    from polar_flow_server.models.user import User
+
+    async with async_session_maker() as session:
+        session.add(
+            User(
+                polar_user_id=polar_user_id,
+                access_token_encrypted=token_encryption.encrypt("fake-polar-token"),
+                is_active=True,
+            )
+        )
+        await session.commit()
+    return polar_user_id
+
+
+async def test_trigger_sync_starts_and_status_shows_result(app_client, monkeypatch) -> None:
+    import asyncio
+
+    from polar_flow_server.models.sync_log import SyncLog, SyncTrigger
+    from polar_flow_server.services.sync_orchestrator import SyncOrchestrator
+
+    async def fake_sync_user(self, user_id, polar_token, trigger=SyncTrigger.MANUAL, **kwargs):
+        from datetime import UTC, datetime
+
+        assert polar_token == "fake-polar-token"  # decrypted from the stored token
+        async with async_session_maker() as session:
+            # started_at is a server default - set it explicitly so
+            # complete_success can compute duration before the flush
+            log = SyncLog(
+                user_id=user_id,
+                job_id="test-job",
+                trigger=trigger.value,
+                started_at=datetime.now(UTC),
+            )
+            log.complete_success(records={"sleep": 3}, api_calls=13)
+            session.add(log)
+            await session.commit()
+        return log
+
+    monkeypatch.setattr(SyncOrchestrator, "sync_user", fake_sync_user)
+
+    user_id = await _seed_syncable_user()
+    raw_key = await _user_key(user_id)
+
+    async with _mcp_client(app_client.app, raw_key) as client:
+        started = await client.call_tool("trigger_sync", {})
+        assert not started.is_error
+        assert started.structured_content["status"] == "started"
+
+        # Poll get_sync_status until the background sync lands (fake = fast)
+        last_sync = None
+        for _ in range(50):
+            status = await client.call_tool("get_sync_status", {})
+            assert not status.is_error
+            last_sync = status.structured_content["last_sync"]
+            if last_sync is not None:
+                break
+            await asyncio.sleep(0.1)
+
+    assert last_sync is not None, "background sync never recorded a SyncLog"
+    assert last_sync["status"] == "success"
+    assert last_sync["trigger"] == "manual"
+    assert last_sync["records_synced"] == {"sleep": 3}
+
+
+async def test_trigger_sync_reports_already_running(app_client) -> None:
+    from polar_flow_server.services.sync_guard import sync_slot
+
+    user_id = await _seed_syncable_user()
+    raw_key = await _user_key(user_id)
+
+    async with _mcp_client(app_client.app, raw_key) as client:
+        with sync_slot(user_id):
+            result = await client.call_tool("trigger_sync", {})
+
+    assert not result.is_error
+    assert result.structured_content["status"] == "already_running"
+
+
+async def test_trigger_sync_honours_rate_limit_cooldown(app_client) -> None:
+    from polar_flow_server.services.sync_orchestrator import shared_rate_limit_tracker
+
+    user_id = await _seed_syncable_user()
+    raw_key = await _user_key(user_id)
+
+    shared_rate_limit_tracker.note_rate_limited(retry_after_seconds=600)
+    try:
+        async with _mcp_client(app_client.app, raw_key) as client:
+            result = await client.call_tool("trigger_sync", {})
+            status = await client.call_tool("get_sync_status", {})
+    finally:
+        shared_rate_limit_tracker.rate_limited_until = None  # module singleton
+
+    assert not result.is_error
+    assert result.structured_content["status"] == "rate_limited"
+    assert result.structured_content["retry_after_seconds"] > 0
+    assert status.structured_content["polar_rate_limit"]["rate_limited_until"] is not None
+
+
+async def test_get_sync_status_before_any_sync(app_client) -> None:
+    user_id = await _seed_user()
+    raw_key = await _user_key(user_id)
+
+    async with _mcp_client(app_client.app, raw_key) as client:
+        result = await client.call_tool("get_sync_status", {})
+
+    assert not result.is_error
+    payload = result.structured_content
+    assert payload["currently_syncing"] is False
+    assert payload["last_sync"] is None
 
 
 async def test_rest_api_still_works_after_refactor(app_client) -> None:


### PR DESCRIPTION
Part 3 of #80, **stacked on #115** (train order: #114 → #115 → this). Closes #80.

## Sync control

- `trigger_sync` — starts an orchestrated background sync using the server's stored (encrypted) Polar token, the same path as the admin *Sync Now* button. Returns immediately with `started` / `already_running` (in-progress guard) / `rate_limited` (+ `retry_after_seconds` from the shared Polar rate-limit tracker).
- `get_sync_status` — the poll side: live in-progress flag, the last `SyncLog` audit record (status, trigger, times, per-endpoint counts, errors), and the current Polar rate-limit state including cooldowns.

Trigger+poll rather than the spec's Tasks extension is deliberate: SEP-2663 didn't make SDK v2.0.0 (upstream issue #3226). The tool surface swaps cleanly when it lands.

## Docs

- New **docs/mcp-server.md**: what it is, auth + scoping model, `claude mcp add` setup, tool table, operator notes (CSRF exclusion, auth-before-protocol, offline-friendly).
- README section + mkdocs nav + CLAUDE.md layout entry.
- `docs/index.md` finally claims a **shipped** MCP server truthfully — `test_docs_accuracy` updated to pin the new claim instead of the old "planned" wording (that's the #88 guard doing its job in reverse).

## Tests

4 new (25 total in the file): background trigger → status-poll round-trip against a monkeypatched orchestrator (asserts the stored token decrypts and the SyncLog lands), `already_running` via a held sync slot, rate-limit cooldown honoured (singleton reset in `finally`), and the pre-first-sync empty status.