### PR TITLE
MCP OAuth sign-in: Connect from Claude Desktop, log in on your own server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,11 @@ SYNC_MAX_USERS_PER_RUN=10            # Max users per sync cycle (default: 10)
 SYNC_STAGGER_SECONDS=5               # Delay between user syncs (default: 5)
 SYNC_DAYS_LOOKBACK=30                # Days of history to sync
 
+# Public URL of this server. Required for the MCP connector OAuth sign-in
+# (it becomes the OAuth issuer, so it must be HTTPS) and used for OAuth
+# callback links. Without it, /mcp still works with API keys.
+# BASE_URL=https://polar.example.com
+
 # Logging
 LOG_LEVEL=INFO
 

--- a/README.md
+++ b/README.md
@@ -106,8 +106,13 @@ managed from the settings page, with rate limit tracking.
 A built-in [Model Context Protocol](https://modelcontextprotocol.io) server
 (protocol revision 2026-07-28, streamable HTTP) lets AI assistants query your
 health data directly - "how has my sleep trended vs my baseline?", "should I
-train hard today?". It runs inside the main server at `/mcp`, authenticated
-with the same API keys as the REST API:
+train hard today?". It runs inside the main server at `/mcp`.
+
+With `BASE_URL` set, the server is its own OAuth 2.1 authorization server:
+add it as a custom connector in Claude Desktop / claude.ai, click
+**Connect**, sign in on your server, approve — no keys to paste. Connected
+apps are listed (and revocable) in Settings. API keys also work for
+headless clients:
 
 ```bash
 claude mcp add polar-health https://your-server.example.com/mcp \

--- a/alembic/versions/g8h9i0j1k2l3_add_oauth_tables.py
+++ b/alembic/versions/g8h9i0j1k2l3_add_oauth_tables.py
@@ -1,0 +1,75 @@
+"""Add OAuth 2.1 authorization-server tables for the MCP connector flow.
+
+Revision ID: g8h9i0j1k2l3
+Revises: f7g8h9i0j1k2
+Create Date: 2026-08-04 16:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "g8h9i0j1k2l3"
+down_revision: str | None = "f7g8h9i0j1k2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create oauth_clients, oauth_auth_codes, and oauth_tokens tables."""
+    op.create_table(
+        "oauth_clients",
+        sa.Column("client_id", sa.String(64), primary_key=True),
+        sa.Column(
+            "client_metadata",
+            sa.JSON(),
+            nullable=False,
+            comment="Full RFC 7591 client metadata, revalidated on load",
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+    op.create_table(
+        "oauth_auth_codes",
+        sa.Column("code_hash", sa.String(64), primary_key=True, comment="SHA-256 of the code"),
+        sa.Column("client_id", sa.String(64), nullable=False),
+        sa.Column("subject", sa.String(255), nullable=False, comment="polar_user_id"),
+        sa.Column("scopes", sa.JSON(), nullable=False),
+        sa.Column("expires_at", sa.Float(), nullable=False, comment="Unix seconds"),
+        sa.Column("code_challenge", sa.String(255), nullable=False, comment="PKCE S256 challenge"),
+        sa.Column("redirect_uri", sa.String(1024), nullable=False),
+        sa.Column("redirect_uri_provided_explicitly", sa.Boolean(), nullable=False, default=True),
+        sa.Column("resource", sa.String(1024), nullable=True),
+    )
+
+    op.create_table(
+        "oauth_tokens",
+        sa.Column("token_hash", sa.String(64), primary_key=True, comment="SHA-256 of the token"),
+        sa.Column("token_type", sa.String(10), nullable=False, comment="access or refresh"),
+        sa.Column(
+            "pair_id",
+            sa.String(36),
+            nullable=False,
+            index=True,
+            comment="Access+refresh issued together share this; revocation hits the pair",
+        ),
+        sa.Column("client_id", sa.String(64), nullable=False, index=True),
+        sa.Column("subject", sa.String(255), nullable=False),
+        sa.Column("scopes", sa.JSON(), nullable=False),
+        sa.Column(
+            "expires_at", sa.Float(), nullable=True, comment="Unix seconds, null = no expiry"
+        ),
+        sa.Column("revoked", sa.Boolean(), nullable=False, default=False, index=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+
+def downgrade() -> None:
+    """Drop the OAuth tables."""
+    op.drop_table("oauth_tokens")
+    op.drop_table("oauth_auth_codes")
+    op.drop_table("oauth_clients")

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -18,12 +18,29 @@ https://your-server.example.com/mcp
 
 ## Authentication
 
-The MCP endpoint uses the same API keys as the REST API, sent as an
-`X-API-Key` header or `Authorization: Bearer` token. Create a key in the
-admin dashboard (Settings → API Keys).
+Two ways in, and the right one depends on the client:
 
-Scoping is identical to the REST API and enforced before any MCP protocol
-handling:
+### OAuth sign-in (the "Connect" button)
+
+With `BASE_URL` set (self-hosted mode), the server is a full OAuth 2.1
+authorization server: MCP clients discover it via the standard metadata
+documents, register themselves dynamically, and send you through a real
+sign-in — your admin login plus a consent screen — instead of pasting keys.
+Issued tokens are scoped to the connected user, expire after an hour
+(refresh tokens rotate), and every connected app is listed in
+Settings → Connected Applications with a one-click revoke.
+
+```bash
+# .env - the public URL becomes the OAuth issuer
+BASE_URL=https://your-server.example.com
+```
+
+### API keys (headless / scripting)
+
+The same API keys as the REST API always work, sent as an `X-API-Key`
+header or as a bearer token. Create one in the admin dashboard
+(Settings → API Keys). Scoping is identical to the REST API and enforced
+before any MCP protocol handling:
 
 - **User-scoped keys** can only ever read their own user's data. Tools need
   no `user_id` argument — the key decides.
@@ -34,20 +51,29 @@ Rate limits are shared with the REST API (per key, per hour).
 
 ## Connecting a client
 
+### Claude Desktop / claude.ai (OAuth)
+
+Add a custom connector with URL `https://your-server.example.com/mcp` and
+click **Connect** — your browser opens the server's login, you approve the
+consent screen, done. No keys to copy.
+
 ### Claude Code
 
 ```bash
+# OAuth (with BASE_URL configured): authenticate interactively
+claude mcp add polar-health https://your-server.example.com/mcp --transport http
+
+# Or with an API key
 claude mcp add polar-health https://your-server.example.com/mcp \
   --transport http \
   --header "X-API-Key: pfk_your_key_here"
 ```
 
-### Claude Desktop / other clients
+### Other clients
 
-Add a custom connector / remote MCP server with URL
-`https://your-server.example.com/mcp`. If the client supports custom
-headers, set `X-API-Key`; if it only supports bearer auth, use your API key
-as the bearer token.
+Any MCP client speaking streamable HTTP works: OAuth via the standard
+discovery chain, or an API key as a bearer/header if the client supports
+fixed credentials.
 
 ### Verify
 

--- a/src/polar_flow_server/admin/routes.py
+++ b/src/polar_flow_server/admin/routes.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 from datetime import UTC, date, datetime, timedelta
 from ipaddress import IPv4Network, IPv6Network, ip_address, ip_network
 from typing import Annotated, Any
-from urllib.parse import urlencode
+from urllib.parse import quote, urlencode
 
 import httpx
 from litestar import Request, get, post
@@ -534,8 +534,18 @@ async def login_form(request: Request[Any, Any, Any], session: AsyncSession) -> 
 
     return Template(
         template_name="admin/login.html",
-        context={"csrf_token": _get_csrf_token(request)},
+        context={
+            "csrf_token": _get_csrf_token(request),
+            "next": _safe_next_path(request.query_params.get("next")),
+        },
     )
+
+
+def _safe_next_path(raw: str | None) -> str | None:
+    """Only allow post-login redirects to admin-local paths (no open redirect)."""
+    if raw and raw.startswith("/admin/") and "//" not in raw and "\\" not in raw:
+        return raw
+    return None
 
 
 def _trusted_proxy_matchers() -> tuple[set[str], list[IPv4Network | IPv6Network]]:
@@ -647,7 +657,8 @@ async def login_submit(
     # Successful login - clear any failed attempts
     await _login_rate_limiter.record_success(client_ip)
     await login_admin(request, admin)
-    return Redirect(path="/admin", status_code=HTTP_303_SEE_OTHER)
+    next_path = _safe_next_path(str(form_data.get("next", "")) or None)
+    return Redirect(path=next_path or "/admin", status_code=HTTP_303_SEE_OTHER)
 
 
 @post("/logout", sync_to_thread=False)
@@ -655,6 +666,102 @@ async def logout(request: Request[Any, Any, Any]) -> Redirect:
     """Log out and redirect to login page."""
     logout_admin(request)
     return Redirect(path="/admin/login", status_code=HTTP_303_SEE_OTHER)
+
+
+# =============================================================================
+# OAuth consent (the human half of the MCP connector sign-in flow)
+#
+# The SDK's /authorize endpoint validates the client and redirects here with
+# a signed blob of the authorization params. The admin logs in (if needed),
+# approves or denies, and we redirect back to the client with a code or an
+# access_denied error. Only exists when BASE_URL is configured (self-hosted).
+# =============================================================================
+
+
+def _consent_error(request: Request[Any, Any, Any], message: str) -> Template:
+    return Template(
+        template_name="admin/oauth_consent.html",
+        context={"error": message, "csrf_token": _get_csrf_token(request)},
+    )
+
+
+@get("/oauth/consent", sync_to_thread=False)
+async def oauth_consent_form(
+    request: Request[Any, Any, Any], session: AsyncSession
+) -> Template | Redirect:
+    """Show the consent screen for a pending OAuth authorization request."""
+    if not is_authenticated(request):
+        target = quote(f"/admin/oauth/consent?req={request.query_params.get('req', '')}", safe="")
+        return Redirect(path=f"/admin/login?next={target}", status_code=HTTP_303_SEE_OTHER)
+
+    from polar_flow_server.mcp_server.oauth import PolarOAuthProvider, unpack_consent_request
+
+    data = unpack_consent_request(str(request.query_params.get("req", "")))
+    if data is None:
+        return _consent_error(
+            request, "This authorization request is invalid or has expired. Retry from the app."
+        )
+
+    client = await PolarOAuthProvider().get_client(data["client_id"])
+    if client is None:
+        return _consent_error(request, "Unknown application. Retry the connection from the app.")
+
+    user_id = await _connected_user_id(session)
+    if user_id is None:
+        return _consent_error(
+            request, "No Polar account is connected yet - complete setup before authorizing apps."
+        )
+
+    return Template(
+        template_name="admin/oauth_consent.html",
+        context={
+            "client_name": client.client_name or client.client_id,
+            "user_id": user_id,
+            "req": request.query_params.get("req", ""),
+            "csrf_token": _get_csrf_token(request),
+        },
+    )
+
+
+@post("/oauth/consent", sync_to_thread=False)
+async def oauth_consent_submit(
+    request: Request[Any, Any, Any], session: AsyncSession
+) -> Template | Redirect:
+    """Complete a consent decision: mint a code (approve) or bounce (deny)."""
+    if not is_authenticated(request):
+        return Redirect(path="/admin/login", status_code=HTTP_303_SEE_OTHER)
+
+    from mcp.server.auth.provider import construct_redirect_uri
+
+    from polar_flow_server.mcp_server.oauth import (
+        PolarOAuthProvider,
+        build_consent_redirect,
+        unpack_consent_request,
+    )
+
+    form_data = await request.form()
+    data = unpack_consent_request(str(form_data.get("req", "")))
+    if data is None:
+        return _consent_error(
+            request, "This authorization request is invalid or has expired. Retry from the app."
+        )
+
+    if form_data.get("action") != "approve":
+        return Redirect(
+            path=construct_redirect_uri(
+                data["redirect_uri"], error="access_denied", state=data["state"]
+            ),
+            status_code=HTTP_303_SEE_OTHER,
+        )
+
+    user_id = await _connected_user_id(session)
+    if user_id is None:
+        return _consent_error(
+            request, "No Polar account is connected yet - complete setup before authorizing apps."
+        )
+
+    code = await PolarOAuthProvider().create_authorization_code(data, user_id)
+    return Redirect(path=build_consent_redirect(data, code), status_code=HTTP_303_SEE_OTHER)
 
 
 @post("/setup/oauth", sync_to_thread=False, status_code=HTTP_200_OK)
@@ -1255,9 +1362,42 @@ async def admin_settings(
         "partial_24h": sum(1 for s in recent_syncs if s.status == "partial"),
     }
 
+    # MCP connector apps (OAuth clients) with their live token counts
+    from polar_flow_server.models.oauth import OAuthClient, OAuthIssuedToken
+
+    oauth_clients = (
+        (await session.execute(select(OAuthClient).order_by(OAuthClient.created_at.desc())))
+        .scalars()
+        .all()
+    )
+    now_ts = datetime.now(UTC).timestamp()
+    token_count_rows = (
+        await session.execute(
+            select(OAuthIssuedToken.client_id, func.count())
+            .where(
+                OAuthIssuedToken.revoked == False,  # noqa: E712
+                OAuthIssuedToken.token_type == "access",
+                OAuthIssuedToken.expires_at > now_ts,
+            )
+            .group_by(OAuthIssuedToken.client_id)
+        )
+    ).all()
+    token_counts: dict[str, int] = {str(cid): int(n) for cid, n in token_count_rows}
+    oauth_apps = [
+        {
+            "client_id": c.client_id,
+            "name": c.client_metadata.get("client_name") or c.client_id,
+            "created_at": c.created_at,
+            "active_tokens": token_counts.get(c.client_id, 0),
+        }
+        for c in oauth_clients
+    ]
+
     return Template(
         template_name="admin/settings.html",
         context={
+            "csrf_token": _get_csrf_token(request),
+            "oauth_apps": oauth_apps,
             "has_credentials": bool(app_settings and app_settings.polar_client_id),
             "client_id": app_settings.polar_client_id if app_settings else None,
             "connected_user": connected_user,
@@ -1288,6 +1428,28 @@ async def admin_settings(
             "sync_stats": sync_stats,
         },
     )
+
+
+@post("/oauth-apps/revoke", sync_to_thread=False)
+async def revoke_oauth_app(request: Request[Any, Any, Any], session: AsyncSession) -> Redirect:
+    """Revoke every token an MCP connector app holds (from Settings)."""
+    if not is_authenticated(request):
+        return Redirect(path="/admin/login", status_code=HTTP_303_SEE_OTHER)
+
+    from sqlalchemy import update as sa_update
+
+    from polar_flow_server.models.oauth import OAuthIssuedToken
+
+    form_data = await request.form()
+    client_id = str(form_data.get("client_id", ""))
+    if client_id:
+        await session.execute(
+            sa_update(OAuthIssuedToken)
+            .where(OAuthIssuedToken.client_id == client_id)
+            .values(revoked=True)
+        )
+        await session.commit()
+    return Redirect(path="/admin/settings", status_code=HTTP_303_SEE_OTHER)
 
 
 @post("/settings/reset-oauth", sync_to_thread=False, status_code=HTTP_200_OK)
@@ -1924,6 +2086,10 @@ admin_routes = [
     oauth_authorize,
     admin_settings,
     reset_oauth_credentials,
+    # MCP connector OAuth consent (auth required via session check)
+    oauth_consent_form,
+    oauth_consent_submit,
+    revoke_oauth_app,
     # API Key management
     admin_regenerate_api_key,
     admin_revoke_api_key,

--- a/src/polar_flow_server/app.py
+++ b/src/polar_flow_server/app.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, date, datetime
 from pathlib import Path
+from typing import Any
 
 import structlog
 from advanced_alchemy.config.asyncio import AsyncSessionConfig
@@ -16,12 +17,13 @@ from litestar.openapi import OpenAPIConfig
 from litestar.static_files import create_static_files_router
 from litestar.stores.memory import MemoryStore
 from litestar.template.config import TemplateConfig
+from mcp.server.auth.settings import AuthSettings, ClientRegistrationOptions, RevocationOptions
 
 from polar_flow_server import __version__
 from polar_flow_server.admin import admin_router
 from polar_flow_server.admin.auth import admin_user_exists
 from polar_flow_server.api import api_routers
-from polar_flow_server.core.config import settings
+from polar_flow_server.core.config import DeploymentMode, settings
 from polar_flow_server.core.database import (
     async_session_maker,
     close_database,
@@ -156,8 +158,38 @@ def create_app() -> Litestar:
     # session_manager.run() is single-use, and tests call create_app()
     # repeatedly. The transport requires the manager running for the app's
     # lifetime — without this lifespan the first /mcp request 500s.
-    mcp_server = build_mcp_server()
-    mcp_mount = create_mcp_mount(mcp_server)
+    #
+    # OAuth mode (the Claude "Connect" sign-in flow) needs the server to
+    # know its public URL (it becomes the OAuth issuer) and only makes sense
+    # self-hosted, where the admin who approves consent IS the data's user.
+    oauth_enabled = (
+        bool(settings.base_url) and settings.deployment_mode == DeploymentMode.SELF_HOSTED
+    )
+    oauth_handlers: list[Any] = []
+    if oauth_enabled:
+        from pydantic import AnyHttpUrl
+
+        from polar_flow_server.mcp_server.asgi import create_oauth_root_mounts
+        from polar_flow_server.mcp_server.oauth import (
+            OAUTH_SCOPE,
+            PolarOAuthProvider,
+            PolarTokenVerifier,
+        )
+
+        base = str(settings.base_url).rstrip("/")
+        auth_settings = AuthSettings(
+            issuer_url=AnyHttpUrl(base),
+            resource_server_url=AnyHttpUrl(f"{base}/mcp"),
+            client_registration_options=ClientRegistrationOptions(
+                enabled=True, valid_scopes=[OAUTH_SCOPE], default_scopes=[OAUTH_SCOPE]
+            ),
+            revocation_options=RevocationOptions(enabled=True),
+        )
+        mcp_server = build_mcp_server(token_verifier=PolarTokenVerifier(), auth=auth_settings)
+        oauth_handlers = list(create_oauth_root_mounts(PolarOAuthProvider(), auth_settings))
+    else:
+        mcp_server = build_mcp_server()
+    mcp_mount = create_mcp_mount(mcp_server, oauth_enabled=oauth_enabled)
 
     @asynccontextmanager
     async def mcp_lifespan(app: Litestar) -> AsyncIterator[None]:
@@ -208,6 +240,13 @@ def create_app() -> Litestar:
             "/api/v1/users/",
             # MCP endpoint: JSON-RPC POSTs authenticated by API key, no CSRF
             "/mcp",
+            # OAuth AS endpoints: external clients POST here (token exchange,
+            # DCR, revocation) with their own auth, never browser forms
+            "/authorize",
+            "/token",
+            "/register",
+            "/revoke",
+            "/.well-known",
             # Health check (no auth needed)
             "/health",
         ],
@@ -222,6 +261,7 @@ def create_app() -> Litestar:
             # the admin UI must work offline / on a LAN with no CDNs (#71).
             create_static_files_router(path="/static", directories=[static_dir]),
             mcp_mount,
+            *oauth_handlers,
         ],
         lifespan=[lifespan, mcp_lifespan],
         openapi_config=OpenAPIConfig(

--- a/src/polar_flow_server/mcp_server/asgi.py
+++ b/src/polar_flow_server/mcp_server/asgi.py
@@ -1,10 +1,22 @@
-"""Litestar mount for the MCP endpoint, with API-key authentication.
+"""Litestar mounts for the MCP endpoint and the OAuth authorization server.
 
-The SDK's streamable-HTTP transport is a plain Starlette ASGI app; we mount
-it at ``/mcp`` behind the same key validation the REST API uses
-(``resolve_key_scope``). Auth happens at the HTTP layer BEFORE any MCP
-protocol handling, so an unauthenticated request never reaches the protocol
-code, and the resolved scope travels to tools via a contextvar.
+Two auth modes for ``/mcp``:
+
+- **API-key only** (no ``BASE_URL`` configured): the mount validates
+  X-API-Key / Bearer keys itself, exactly as the REST guard does, and
+  rejects everything else before the protocol layer.
+- **OAuth mode** (``BASE_URL`` set, self-hosted): the SDK's bearer
+  middleware guards the MCP route through :class:`PolarTokenVerifier`, which
+  accepts issued OAuth access tokens and raw API keys alike. Requests
+  without credentials get the spec's 401 + ``WWW-Authenticate`` pointing at
+  the protected-resource metadata - that discovery chain is what makes the
+  "Connect" button in MCP clients work. X-API-Key headers are still
+  honoured: the mount validates them (keeping the 429 rate-limit contract)
+  and injects the key as a bearer so one pipeline authenticates.
+
+The authorization-server endpoints (/authorize, /token, /register, /revoke,
+/.well-known/*) must live at the site root - the issuer - not under /mcp,
+so they're mounted as their own handlers.
 """
 
 import json
@@ -14,29 +26,91 @@ from litestar import asgi
 from litestar.exceptions import NotAuthorizedException
 from litestar.handlers import ASGIRouteHandler
 from litestar.types import Receive, Scope, Send
+from mcp.server.auth.provider import OAuthAuthorizationServerProvider
+from mcp.server.auth.routes import create_auth_routes, create_protected_resource_routes
+from mcp.server.auth.settings import AuthSettings
 from mcp.server.mcpserver import MCPServer
 from mcp.server.transport_security import TransportSecuritySettings
+from starlette.applications import Starlette
 
 from polar_flow_server.core.auth import RateLimitExceeded, resolve_key_scope
 from polar_flow_server.mcp_server.context import current_key_scope
 
 MCP_PATH = "/mcp"
 
+# Root-level paths the OAuth flow needs (see module docstring)
+OAUTH_ROOT_PATHS = ("/.well-known", "/authorize", "/token", "/register", "/revoke")
 
-def create_mcp_mount(server: MCPServer) -> ASGIRouteHandler:
-    """Build the authenticated ``/mcp`` mount for a Litestar app."""
+
+def create_mcp_mount(server: MCPServer, *, oauth_enabled: bool = False) -> ASGIRouteHandler:
+    """Build the ``/mcp`` mount for a Litestar app."""
     mcp_asgi = server.streamable_http_app(
         streamable_http_path="/",
         # Host-header (DNS-rebinding) checks default to localhost-only and
         # would 421 behind the reverse proxy. Rebinding attacks are moot
-        # here anyway: every request must carry an API key, which a rebound
+        # here anyway: every request must carry a credential a rebound
         # browser origin cannot attach.
         transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
     )
 
     @asgi(MCP_PATH, is_mount=True, name="mcp", copy_scope=True)
     async def mcp_mount(scope: Scope, receive: Receive, send: Send) -> None:
-        raw_key = _extract_api_key(scope)
+        # Normalize the path for the sub-app: it serves the MCP endpoint at
+        # "/" and must see the mount prefix stripped, whatever Litestar passed.
+        subpath = scope["path"]
+        if subpath.startswith(MCP_PATH):
+            subpath = subpath[len(MCP_PATH) :]
+        sub_scope: Any = {**scope, "path": subpath or "/", "root_path": ""}
+
+        async def delegate() -> None:
+            await mcp_asgi(sub_scope, cast(Any, receive), cast(Any, send))
+
+        if oauth_enabled:
+            if sub_scope["path"] != "/":
+                # Non-endpoint paths inside the sub-app (e.g. its copy of the
+                # protected-resource metadata) are public.
+                await delegate()
+                return
+
+            raw_x_key = _header(scope, b"x-api-key")
+            if raw_x_key is None:
+                # Bearer (OAuth token or API key) or no credentials at all:
+                # the SDK middleware + PolarTokenVerifier decide, and produce
+                # spec-compliant 401s with WWW-Authenticate.
+                await delegate()
+                return
+
+            # Explicit X-API-Key keeps the legacy contract (429s intact)
+            try:
+                key_scope = await resolve_key_scope(raw_x_key)
+            except RateLimitExceeded as exc:
+                await _send_json(
+                    send,
+                    429,
+                    {"error": str(exc.detail)},
+                    extra_headers=[(b"retry-after", str(exc.retry_after).encode())],
+                )
+                return
+            except NotAuthorizedException as exc:
+                await _send_json(send, 401, {"error": str(exc.detail)})
+                return
+
+            if _header(scope, b"authorization") is None:
+                # Feed the validated key through the bearer pipeline; the
+                # verifier sees the contextvar and won't re-validate.
+                sub_scope["headers"] = [
+                    *sub_scope["headers"],
+                    (b"authorization", b"Bearer " + raw_x_key.encode("latin-1")),
+                ]
+            token = current_key_scope.set(key_scope)
+            try:
+                await delegate()
+            finally:
+                current_key_scope.reset(token)
+            return
+
+        # API-key-only mode: authenticate here, before any protocol handling
+        raw_key = _header(scope, b"x-api-key") or _bearer(scope)
         if not raw_key:
             await _send_json(send, 401, {"error": "Missing API key. Use X-API-Key header."})
             return
@@ -55,37 +129,72 @@ def create_mcp_mount(server: MCPServer) -> ASGIRouteHandler:
             await _send_json(send, 401, {"error": str(exc.detail)})
             return
 
-        # Normalize the path for the sub-app: it serves at "/" and must see
-        # the path with the mount prefix stripped, whatever Litestar passed.
-        subpath = scope["path"]
-        if subpath.startswith(MCP_PATH):
-            subpath = subpath[len(MCP_PATH) :]
-        sub_scope: Any = {**scope, "path": subpath or "/", "root_path": ""}
-
         token = current_key_scope.set(key_scope)
         try:
-            # Litestar and Starlette type their ASGI callables differently;
-            # both are the same protocol at runtime.
-            await mcp_asgi(sub_scope, cast(Any, receive), cast(Any, send))
+            await delegate()
         finally:
             current_key_scope.reset(token)
 
     return mcp_mount
 
 
-def _extract_api_key(scope: Scope) -> str | None:
-    """Pull the API key from X-API-Key or Authorization: Bearer headers."""
-    api_key: str | None = None
-    bearer: str | None = None
-    for name, value in scope.get("headers", []):
-        lowered = name.lower()
-        if lowered == b"x-api-key":
-            api_key = value.decode("latin-1")
-        elif lowered == b"authorization":
-            decoded = value.decode("latin-1")
-            if decoded.startswith("Bearer "):
-                bearer = decoded[7:]
-    return api_key or bearer
+def create_oauth_root_mounts(
+    provider: OAuthAuthorizationServerProvider[Any, Any, Any],
+    auth: AuthSettings,
+) -> list[ASGIRouteHandler]:
+    """Mount the SDK's authorization-server routes at the site root."""
+    oauth_app = Starlette(
+        routes=[
+            *create_auth_routes(
+                provider=provider,
+                issuer_url=auth.issuer_url,
+                client_registration_options=auth.client_registration_options,
+                revocation_options=auth.revocation_options,
+            ),
+            *create_protected_resource_routes(
+                resource_url=auth.resource_server_url,  # type: ignore[arg-type]
+                authorization_servers=[auth.issuer_url],
+                scopes_supported=auth.required_scopes,
+            ),
+        ]
+    )
+
+    def make_handler(prefix: str) -> ASGIRouteHandler:
+        @asgi(
+            prefix,
+            is_mount=True,
+            name=f"oauth-{prefix.strip('/').replace('/', '-').replace('.', '')}",
+            copy_scope=True,
+        )
+        async def handler(scope: Scope, receive: Receive, send: Send) -> None:
+            # The Starlette app's routes use absolute root paths; restore the
+            # prefix if the mount stripped it, and drop the trailing slash
+            # Litestar appends (Starlette would slash-redirect forever).
+            path = scope["path"]
+            if not path.startswith(prefix):
+                path = prefix + ("" if path == "/" else path)
+            if len(path) > 1:
+                path = path.rstrip("/")
+            sub_scope: Any = {**scope, "path": path, "root_path": ""}
+            await oauth_app(sub_scope, cast(Any, receive), cast(Any, send))
+
+        return handler
+
+    return [make_handler(prefix) for prefix in OAUTH_ROOT_PATHS]
+
+
+def _header(scope: Scope, name: bytes) -> str | None:
+    for key, value in scope.get("headers", []):
+        if key.lower() == name:
+            return value.decode("latin-1")
+    return None
+
+
+def _bearer(scope: Scope) -> str | None:
+    auth_header = _header(scope, b"authorization")
+    if auth_header and auth_header.startswith("Bearer "):
+        return auth_header[7:]
+    return None
 
 
 async def _send_json(

--- a/src/polar_flow_server/mcp_server/oauth.py
+++ b/src/polar_flow_server/mcp_server/oauth.py
@@ -1,0 +1,356 @@
+"""OAuth 2.1 authorization server + token verification for the MCP endpoint.
+
+The SDK provides the protocol endpoints (/authorize, /token, /register,
+/revoke, discovery metadata) and PKCE verification; this module supplies the
+storage-backed provider behind them and the token verifier the resource
+server uses. The human half of /authorize - admin login and the consent
+screen - lives in the admin routes; the handoff between the two is a signed,
+expiring blob of the authorization params (no server-side pending-auth
+state).
+
+Token verification is the single auth funnel for /mcp in OAuth mode: it
+accepts issued OAuth access tokens AND raw API keys presented as bearers,
+resolving both to the same KeyScope contextvar the tools read.
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import secrets
+import time
+import uuid
+from typing import Any
+
+from mcp.server.auth.provider import (
+    AccessToken,
+    AuthorizationCode,
+    AuthorizationParams,
+    RefreshToken,
+    TokenError,
+    TokenVerifier,
+    construct_redirect_uri,
+)
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+from sqlalchemy import update
+
+from polar_flow_server.core.auth import KeyScope, hash_api_key, resolve_key_scope
+from polar_flow_server.core.config import settings
+from polar_flow_server.mcp_server.context import current_key_scope
+from polar_flow_server.models.oauth import OAuthAuthCode, OAuthClient, OAuthIssuedToken
+
+ACCESS_TOKEN_TTL_SECONDS = 3600
+REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 3600
+AUTH_CODE_TTL_SECONDS = 300
+CONSENT_BLOB_TTL_SECONDS = 600
+
+OAUTH_SCOPE = "health"
+
+
+def _sign(payload: bytes) -> str:
+    key = settings.get_session_secret().encode()
+    return hmac.new(key, payload, hashlib.sha256).hexdigest()
+
+
+def pack_consent_request(client_id: str, params: AuthorizationParams) -> str:
+    """Serialize + sign the authorization params for the consent redirect."""
+    payload = json.dumps(
+        {
+            "client_id": client_id,
+            "state": params.state,
+            "scopes": params.scopes,
+            "code_challenge": params.code_challenge,
+            "redirect_uri": str(params.redirect_uri),
+            "redirect_uri_provided_explicitly": params.redirect_uri_provided_explicitly,
+            "resource": params.resource,
+            "exp": time.time() + CONSENT_BLOB_TTL_SECONDS,
+        }
+    ).encode()
+    blob = base64.urlsafe_b64encode(payload).decode().rstrip("=")
+    return f"{blob}.{_sign(payload)}"
+
+
+def unpack_consent_request(blob: str) -> dict[str, Any] | None:
+    """Verify and decode a consent blob; None if tampered or expired."""
+    try:
+        body, signature = blob.rsplit(".", 1)
+        payload = base64.urlsafe_b64decode(body + "=" * (-len(body) % 4))
+    except (ValueError, TypeError):
+        return None
+    if not hmac.compare_digest(_sign(payload), signature):
+        return None
+    data: dict[str, Any] = json.loads(payload)
+    if time.time() > data["exp"]:
+        return None
+    return data
+
+
+class PolarOAuthProvider:
+    """Storage-backed OAuthAuthorizationServerProvider.
+
+    Sessions are opened per call via async_session_maker - the SDK invokes
+    these outside Litestar's dependency injection.
+    """
+
+    async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
+        from polar_flow_server.core.database import async_session_maker
+
+        async with async_session_maker() as session:
+            row = await session.get(OAuthClient, client_id)
+        if row is None:
+            return None
+        return OAuthClientInformationFull.model_validate(row.client_metadata)
+
+    async def register_client(self, client_info: OAuthClientInformationFull) -> None:
+        from polar_flow_server.core.database import async_session_maker
+
+        async with async_session_maker() as session:
+            session.add(
+                OAuthClient(
+                    client_id=client_info.client_id,
+                    client_metadata=client_info.model_dump(mode="json"),
+                )
+            )
+            await session.commit()
+
+    async def authorize(
+        self, client: OAuthClientInformationFull, params: AuthorizationParams
+    ) -> str:
+        # Hand off to the human: admin login + consent page render the
+        # decision; the signed blob carries everything needed to mint the
+        # code once approved.
+        return f"{settings.base_url}/admin/oauth/consent?req={pack_consent_request(client.client_id, params)}"
+
+    async def create_authorization_code(self, data: dict[str, Any], subject: str) -> str:
+        """Mint and store a code for an approved consent (called by the
+        consent route, not the SDK)."""
+        from polar_flow_server.core.database import async_session_maker
+
+        code = f"pfc_{secrets.token_urlsafe(32)}"
+        async with async_session_maker() as session:
+            session.add(
+                OAuthAuthCode(
+                    code_hash=hash_api_key(code),
+                    client_id=data["client_id"],
+                    subject=subject,
+                    scopes=data["scopes"] or [OAUTH_SCOPE],
+                    expires_at=time.time() + AUTH_CODE_TTL_SECONDS,
+                    code_challenge=data["code_challenge"],
+                    redirect_uri=data["redirect_uri"],
+                    redirect_uri_provided_explicitly=data["redirect_uri_provided_explicitly"],
+                    resource=data.get("resource"),
+                )
+            )
+            await session.commit()
+        return code
+
+    async def load_authorization_code(
+        self, client: OAuthClientInformationFull, authorization_code: str
+    ) -> AuthorizationCode | None:
+        from polar_flow_server.core.database import async_session_maker
+
+        async with async_session_maker() as session:
+            row = await session.get(OAuthAuthCode, hash_api_key(authorization_code))
+        if row is None or row.client_id != client.client_id or time.time() > row.expires_at:
+            return None
+        return AuthorizationCode(
+            code=authorization_code,
+            scopes=list(row.scopes),
+            expires_at=row.expires_at,
+            client_id=row.client_id,
+            code_challenge=row.code_challenge,
+            redirect_uri=row.redirect_uri,
+            redirect_uri_provided_explicitly=row.redirect_uri_provided_explicitly,
+            resource=row.resource,
+            subject=row.subject,
+        )
+
+    async def exchange_authorization_code(
+        self, client: OAuthClientInformationFull, authorization_code: AuthorizationCode
+    ) -> OAuthToken:
+        from polar_flow_server.core.database import async_session_maker
+
+        subject = authorization_code.subject or ""
+        async with async_session_maker() as session:
+            # Single use: delete before issuing; a replayed code gets nothing
+            row = await session.get(OAuthAuthCode, hash_api_key(authorization_code.code))
+            if row is None:
+                raise TokenError("invalid_grant", "Authorization code already used")
+            await session.delete(row)
+            token = await self._issue_pair(
+                session, client.client_id, subject, authorization_code.scopes
+            )
+            await session.commit()
+        return token
+
+    async def load_refresh_token(
+        self, client: OAuthClientInformationFull, refresh_token: str
+    ) -> RefreshToken | None:
+        from polar_flow_server.core.database import async_session_maker
+
+        async with async_session_maker() as session:
+            row = await session.get(OAuthIssuedToken, hash_api_key(refresh_token))
+        if (
+            row is None
+            or row.token_type != "refresh"
+            or row.revoked
+            or row.client_id != client.client_id
+            or (row.expires_at is not None and time.time() > row.expires_at)
+        ):
+            return None
+        return RefreshToken(
+            token=refresh_token,
+            client_id=row.client_id,
+            scopes=list(row.scopes),
+            expires_at=int(row.expires_at) if row.expires_at else None,
+            subject=row.subject,
+        )
+
+    async def exchange_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: RefreshToken,
+        scopes: list[str],
+    ) -> OAuthToken:
+        from polar_flow_server.core.database import async_session_maker
+
+        async with async_session_maker() as session:
+            row = await session.get(OAuthIssuedToken, hash_api_key(refresh_token.token))
+            if row is None or row.revoked:
+                raise TokenError("invalid_grant", "Refresh token is no longer valid")
+            # Rotate: retire the whole old pair, issue a fresh one
+            await session.execute(
+                update(OAuthIssuedToken)
+                .where(OAuthIssuedToken.pair_id == row.pair_id)
+                .values(revoked=True)
+            )
+            token = await self._issue_pair(
+                session, client.client_id, row.subject, scopes or list(row.scopes)
+            )
+            await session.commit()
+        return token
+
+    async def load_access_token(self, token: str) -> AccessToken | None:
+        from polar_flow_server.core.database import async_session_maker
+
+        async with async_session_maker() as session:
+            row = await session.get(OAuthIssuedToken, hash_api_key(token))
+        if (
+            row is None
+            or row.token_type != "access"
+            or row.revoked
+            or (row.expires_at is not None and time.time() > row.expires_at)
+        ):
+            return None
+        return AccessToken(
+            token=token,
+            client_id=row.client_id,
+            scopes=list(row.scopes),
+            expires_at=int(row.expires_at) if row.expires_at else None,
+            subject=row.subject,
+        )
+
+    async def exchange_identity_assertion(
+        self, client: OAuthClientInformationFull, params: Any
+    ) -> OAuthToken:
+        """Identity-assertion grants are not supported (feature disabled)."""
+        raise NotImplementedError("Identity assertion is not supported")
+
+    async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
+        from polar_flow_server.core.database import async_session_maker
+
+        async with async_session_maker() as session:
+            row = await session.get(OAuthIssuedToken, hash_api_key(token.token))
+            if row is None:
+                return
+            # Revoke the pair, per OAuth 2.1 SHOULD
+            await session.execute(
+                update(OAuthIssuedToken)
+                .where(OAuthIssuedToken.pair_id == row.pair_id)
+                .values(revoked=True)
+            )
+            await session.commit()
+
+    async def _issue_pair(
+        self, session: Any, client_id: str, subject: str, scopes: list[str]
+    ) -> OAuthToken:
+        access = f"pfa_{secrets.token_urlsafe(32)}"
+        refresh = f"pfr_{secrets.token_urlsafe(32)}"
+        pair_id = str(uuid.uuid4())
+        now = time.time()
+        session.add(
+            OAuthIssuedToken(
+                token_hash=hash_api_key(access),
+                token_type="access",
+                pair_id=pair_id,
+                client_id=client_id,
+                subject=subject,
+                scopes=scopes,
+                expires_at=now + ACCESS_TOKEN_TTL_SECONDS,
+            )
+        )
+        session.add(
+            OAuthIssuedToken(
+                token_hash=hash_api_key(refresh),
+                token_type="refresh",
+                pair_id=pair_id,
+                client_id=client_id,
+                subject=subject,
+                scopes=scopes,
+                expires_at=now + REFRESH_TOKEN_TTL_SECONDS,
+            )
+        )
+        return OAuthToken(
+            access_token=access,
+            token_type="Bearer",
+            expires_in=ACCESS_TOKEN_TTL_SECONDS,
+            scope=" ".join(scopes) if scopes else None,
+            refresh_token=refresh,
+        )
+
+
+class PolarTokenVerifier(TokenVerifier):
+    """Single auth funnel for /mcp bearers: OAuth tokens and raw API keys.
+
+    Sets the KeyScope contextvar the tools read. If the mount already
+    resolved an X-API-Key header (and injected it as a bearer), the existing
+    contextvar short-circuits re-validation so rate-limit slots aren't
+    double-consumed.
+    """
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        existing = current_key_scope.get()
+        if existing is not None:
+            return _scope_to_access_token(token, existing)
+
+        # Issued OAuth access token?
+        provider = PolarOAuthProvider()
+        access = await provider.load_access_token(token)
+        if access is not None:
+            current_key_scope.set(
+                KeyScope(user_id=access.subject, api_key_id=None, rate_limit_info=None)
+            )
+            return access
+
+        # Raw API key presented as a bearer (headless clients)
+        try:
+            scope = await resolve_key_scope(token)
+        except Exception:  # invalid key or rate-limited -> not authenticated
+            return None
+        current_key_scope.set(scope)
+        return _scope_to_access_token(token, scope)
+
+
+def _scope_to_access_token(token: str, scope: KeyScope) -> AccessToken:
+    return AccessToken(
+        token=token,
+        client_id=f"api-key-{scope.api_key_id}" if scope.api_key_id else "api-key-master",
+        scopes=[OAUTH_SCOPE],
+        expires_at=None,
+        subject=scope.user_id,
+    )
+
+
+def build_consent_redirect(data: dict[str, Any], code: str) -> str:
+    """Redirect URI back to the client with the freshly-minted code."""
+    return construct_redirect_uri(data["redirect_uri"], code=code, state=data["state"])

--- a/src/polar_flow_server/mcp_server/server.py
+++ b/src/polar_flow_server/mcp_server/server.py
@@ -7,6 +7,8 @@ Speaks MCP protocol revision 2026-07-28 (and earlier revisions for older
 clients) via the official ``mcp`` SDK v2.
 """
 
+from mcp.server.auth.provider import TokenVerifier
+from mcp.server.auth.settings import AuthSettings
 from mcp.server.caching import CacheHint
 from mcp.server.mcpserver import MCPServer
 
@@ -43,14 +45,24 @@ _TOOLS = (
 )
 
 
-def build_mcp_server() -> MCPServer:
-    """Create the MCP server with all tools registered."""
+def build_mcp_server(
+    token_verifier: TokenVerifier | None = None,
+    auth: AuthSettings | None = None,
+) -> MCPServer:
+    """Create the MCP server with all tools registered.
+
+    With ``token_verifier`` + ``auth`` (OAuth mode) the SDK guards the MCP
+    route with bearer auth and serves protected-resource metadata; without
+    them the mount in ``asgi.py`` does API-key auth itself.
+    """
     server = MCPServer(
         name="polar-flow-server",
         title="Polar Health Data",
         version=__version__,
         instructions=INSTRUCTIONS,
         website_url="https://github.com/StuMason/polar-flow-server",
+        token_verifier=token_verifier,
+        auth=auth,
         # The tool list only changes on deploy; let clients cache it. Health
         # data responses themselves are never cacheable by intermediaries.
         cache_hints={"tools/list": CacheHint(ttl_ms=3_600_000, scope="private")},

--- a/src/polar_flow_server/models/__init__.py
+++ b/src/polar_flow_server/models/__init__.py
@@ -10,6 +10,7 @@ from polar_flow_server.models.cardio_load import CardioLoad
 from polar_flow_server.models.continuous_hr import ContinuousHeartRate
 from polar_flow_server.models.ecg import ECG
 from polar_flow_server.models.exercise import Exercise
+from polar_flow_server.models.oauth import OAuthAuthCode, OAuthClient, OAuthIssuedToken
 from polar_flow_server.models.pattern import (
     PatternAnalysis,
     PatternName,
@@ -48,6 +49,9 @@ __all__ = [
     "Exercise",
     "MetricName",
     "NightlyRecharge",
+    "OAuthAuthCode",
+    "OAuthClient",
+    "OAuthIssuedToken",
     "PatternAnalysis",
     "PatternName",
     "PatternType",

--- a/src/polar_flow_server/models/oauth.py
+++ b/src/polar_flow_server/models/oauth.py
@@ -1,0 +1,65 @@
+"""OAuth 2.1 authorization-server storage for the MCP connector flow.
+
+polar-flow-server acts as its own OAuth authorization server so MCP clients
+(Claude Desktop and friends) can "Connect" with a real sign-in instead of a
+pasted API key. Clients arrive via Dynamic Client Registration, the admin
+approves a consent screen, and the issued tokens map to the same user scope
+as user-scoped API keys.
+
+Codes and tokens are stored as SHA-256 hashes; raw values never touch disk.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import JSON, Boolean, DateTime, Float, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from polar_flow_server.models.base import Base
+
+
+class OAuthClient(Base):
+    """A dynamically-registered OAuth client (RFC 7591)."""
+
+    __tablename__ = "oauth_clients"
+
+    client_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    # Full OAuthClientInformationFull payload, revalidated on load
+    client_metadata: Mapped[dict[str, object]] = mapped_column(JSON, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class OAuthAuthCode(Base):
+    """A single-use authorization code awaiting exchange."""
+
+    __tablename__ = "oauth_auth_codes"
+
+    code_hash: Mapped[str] = mapped_column(String(64), primary_key=True)
+    client_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    subject: Mapped[str] = mapped_column(String(255), nullable=False)  # polar_user_id
+    scopes: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
+    expires_at: Mapped[float] = mapped_column(Float, nullable=False)  # unix seconds
+    code_challenge: Mapped[str] = mapped_column(String(255), nullable=False)
+    redirect_uri: Mapped[str] = mapped_column(String(1024), nullable=False)
+    redirect_uri_provided_explicitly: Mapped[bool] = mapped_column(Boolean, default=True)
+    resource: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+
+
+class OAuthIssuedToken(Base):
+    """An issued access or refresh token.
+
+    Access and refresh tokens issued together share a pair_id so revoking
+    either revokes both (OAuth 2.1 SHOULD), and refresh rotation retires the
+    whole pair.
+    """
+
+    __tablename__ = "oauth_tokens"
+
+    token_hash: Mapped[str] = mapped_column(String(64), primary_key=True)
+    token_type: Mapped[str] = mapped_column(String(10), nullable=False)  # access | refresh
+    pair_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    client_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    subject: Mapped[str] = mapped_column(String(255), nullable=False)
+    scopes: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
+    expires_at: Mapped[float | None] = mapped_column(Float, nullable=True)
+    revoked: Mapped[bool] = mapped_column(Boolean, default=False, index=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/src/polar_flow_server/templates/admin/login.html
+++ b/src/polar_flow_server/templates/admin/login.html
@@ -18,6 +18,7 @@
 
         <form method="POST" action="/admin/login" class="space-y-6">
             {% if csrf_token %}<input type="hidden" name="_csrf_token" value="{{ csrf_token }}">{% endif %}
+            {% if next %}<input type="hidden" name="next" value="{{ next }}">{% endif %}
             <div>
                 <label for="email" class="block text-sm font-medium text-gray-700 mb-1">
                     Email

--- a/src/polar_flow_server/templates/admin/oauth_consent.html
+++ b/src/polar_flow_server/templates/admin/oauth_consent.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+
+{% block title %}Authorize Access - polar-flow-server{% endblock %}
+
+{% block content %}
+<div class="max-w-md mx-auto mt-8">
+    <div class="bg-white shadow rounded-lg p-8">
+        {% if error %}
+        <div class="text-center mb-4">
+            <h1 class="text-2xl font-bold text-gray-900 mb-2">Authorization Request</h1>
+        </div>
+        <div class="mb-6 bg-red-50 border border-red-200 rounded-lg p-4">
+            <p class="text-sm text-red-700">{{ error }}</p>
+        </div>
+        <a href="/admin" class="w-full inline-flex justify-center items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md shadow-sm text-gray-700 bg-white hover:bg-gray-50">
+            Back to dashboard
+        </a>
+        {% else %}
+        <div class="text-center mb-8">
+            <h1 class="text-2xl font-bold text-gray-900 mb-2">Authorize Access</h1>
+            <p class="text-gray-600">An application wants to connect to your health data</p>
+        </div>
+
+        <div class="mb-6 bg-gray-50 border border-gray-200 rounded-lg p-4 space-y-2">
+            <p class="text-sm text-gray-700"><span class="font-medium">Application:</span> {{ client_name }}</p>
+            <p class="text-sm text-gray-700"><span class="font-medium">Data user:</span> {{ user_id }}</p>
+            <p class="text-sm text-gray-700"><span class="font-medium">Access:</span> read health data, trigger syncs</p>
+        </div>
+
+        <p class="text-sm text-gray-600 mb-6">
+            If you approve, this application receives its own revocable token
+            scoped to this user's data. You can revoke it any time from
+            Settings.
+        </p>
+
+        <form method="POST" action="/admin/oauth/consent" class="flex gap-3">
+            {% if csrf_token %}<input type="hidden" name="_csrf_token" value="{{ csrf_token }}">{% endif %}
+            <input type="hidden" name="req" value="{{ req }}">
+            <button
+                type="submit" name="action" value="deny"
+                class="w-1/2 inline-flex justify-center items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md shadow-sm text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400"
+            >
+                Deny
+            </button>
+            <button
+                type="submit" name="action" value="approve"
+                class="w-1/2 inline-flex justify-center items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+                Approve
+            </button>
+        </form>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/src/polar_flow_server/templates/admin/settings.html
+++ b/src/polar_flow_server/templates/admin/settings.html
@@ -568,6 +568,52 @@
     </div>
 </div>
 
+{% if oauth_apps %}
+<!-- Connected Applications (MCP OAuth) -->
+<div class="mt-8 bg-white shadow rounded-lg">
+    <div class="px-6 py-4 border-b border-gray-200">
+        <h2 class="text-lg font-semibold text-gray-900">Connected Applications</h2>
+        <p class="text-sm text-gray-500 mt-1">
+            Apps you authorized via the MCP connector sign-in. Revoking access
+            invalidates all of an app's tokens immediately.
+        </p>
+    </div>
+    <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Application</th>
+                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Connected</th>
+                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Active tokens</th>
+                    <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-gray-200">
+                {% for app in oauth_apps %}
+                <tr>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ app.name }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ app.created_at | utc_dt }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ app.active_tokens }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-right text-sm">
+                        <form method="POST" action="/admin/oauth-apps/revoke" class="inline">
+                            {% if csrf_token %}<input type="hidden" name="_csrf_token" value="{{ csrf_token }}">{% endif %}
+                            <input type="hidden" name="client_id" value="{{ app.client_id }}">
+                            <button
+                                type="submit"
+                                class="inline-flex items-center px-2.5 py-1.5 border border-transparent text-xs font-medium rounded text-red-700 bg-red-100 hover:bg-red-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+                            >
+                                Revoke access
+                            </button>
+                        </form>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endif %}
+
 <script>
 let currentKeyId = null;
 let currentKeyPrefix = null;

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -1,0 +1,396 @@
+"""OAuth 2.1 flow tests for the MCP connector sign-in (BASE_URL configured).
+
+Drives the complete dance a real MCP client performs: discovery via
+WWW-Authenticate and the .well-known documents, Dynamic Client Registration,
+/authorize with PKCE, admin login + consent, code exchange, authenticated
+MCP calls with the issued bearer, refresh rotation, and revocation.
+"""
+
+import base64
+import hashlib
+import re
+import secrets
+from urllib.parse import parse_qs, urlparse
+
+import httpx2
+import pytest
+from mcp import Client
+from mcp.client.streamable_http import streamable_http_client
+
+from polar_flow_server.core.database import async_session_maker
+
+BASE = "https://testserver.local"
+REDIRECT_URI = "https://client.example/callback"
+
+
+@pytest.fixture
+async def oauth_app_client(monkeypatch):
+    """Full-stack client with OAuth mode on (base_url set before create_app)."""
+    from litestar.testing import AsyncTestClient
+    from sqlalchemy.exc import OperationalError
+
+    import polar_flow_server.models  # noqa: F401 - register all models on Base
+    from polar_flow_server.core.config import settings
+    from polar_flow_server.core.database import engine
+    from polar_flow_server.models.base import Base
+
+    monkeypatch.setattr(settings, "base_url", BASE)
+
+    from polar_flow_server.app import create_app
+
+    await engine.dispose()
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+            await conn.run_sync(Base.metadata.create_all)
+    except (OperationalError, OSError) as exc:  # pragma: no cover
+        pytest.skip(f"Postgres test database unavailable: {exc}")
+
+    try:
+        async with AsyncTestClient(app=create_app(), base_url=BASE) as client:
+            yield client
+    finally:
+        await engine.dispose()
+
+
+async def _seed_admin_and_user(client) -> str:
+    """Admin account + connected user; logs the client's session in."""
+    from polar_flow_server.core.password import hash_password
+    from polar_flow_server.models.admin_user import AdminUser
+    from polar_flow_server.models.user import User
+
+    async with async_session_maker() as session:
+        session.add(
+            AdminUser(
+                email="admin@example.com",
+                password_hash=hash_password("correct-horse-battery"),
+                is_active=True,
+            )
+        )
+        session.add(
+            User(
+                polar_user_id="oauth-user",
+                access_token_encrypted="encrypted-test-token",
+                is_active=True,
+            )
+        )
+        await session.commit()
+
+    response = await client.post(
+        "/admin/login",
+        data={"email": "admin@example.com", "password": "correct-horse-battery"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    return "oauth-user"
+
+
+async def _register_client(client) -> str:
+    response = await client.post(
+        "/register",
+        json={
+            "client_name": "Test MCP Client",
+            "redirect_uris": [REDIRECT_URI],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "none",
+        },
+    )
+    assert response.status_code in (200, 201), response.text
+    return response.json()["client_id"]
+
+
+def _pkce() -> tuple[str, str]:
+    verifier = secrets.token_urlsafe(48)
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).decode().rstrip("=")
+    )
+    return verifier, challenge
+
+
+async def _authorize_and_consent(client, client_id: str, challenge: str) -> str:
+    """Run /authorize -> consent screen -> approve; returns the auth code."""
+    response = await client.get(
+        "/authorize",
+        params={
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": REDIRECT_URI,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "state": "state-123",
+            "scope": "health",
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code in (302, 307), response.text
+    consent_url = response.headers["location"]
+    assert "/admin/oauth/consent" in consent_url
+
+    page = await client.get(consent_url)
+    assert page.status_code == 200
+    assert "Test MCP Client" in page.text
+    match = re.search(r'name="_csrf_token" value="([^"]+)"', page.text)
+    req = re.search(r'name="req" value="([^"]+)"', page.text)
+    assert req is not None
+
+    form = {"req": req.group(1), "action": "approve"}
+    if match:
+        form["_csrf_token"] = match.group(1)
+    approved = await client.post("/admin/oauth/consent", data=form, follow_redirects=False)
+    assert approved.status_code == 303, approved.text
+    location = approved.headers["location"]
+    assert location.startswith(REDIRECT_URI)
+    query = parse_qs(urlparse(location).query)
+    assert query["state"] == ["state-123"]
+    return query["code"][0]
+
+
+async def _exchange_code(client, client_id: str, code: str, verifier: str) -> dict:
+    response = await client.post(
+        "/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": REDIRECT_URI,
+            "client_id": client_id,
+            "code_verifier": verifier,
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def _bearer_mcp_client(app, token: str) -> Client:
+    http_client = httpx2.AsyncClient(
+        transport=httpx2.ASGITransport(app=app),
+        base_url=BASE,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    return Client(streamable_http_client(f"{BASE}/mcp", http_client=http_client))
+
+
+# =============================================================================
+# Discovery
+# =============================================================================
+
+
+async def test_protected_resource_metadata(oauth_app_client) -> None:
+    response = await oauth_app_client.get("/.well-known/oauth-protected-resource/mcp")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["resource"] == f"{BASE}/mcp"
+    assert f"{BASE}/" in body["authorization_servers"] or BASE in body["authorization_servers"]
+
+
+async def test_authorization_server_metadata(oauth_app_client) -> None:
+    response = await oauth_app_client.get("/.well-known/oauth-authorization-server")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["authorization_endpoint"].endswith("/authorize")
+    assert body["token_endpoint"].endswith("/token")
+    assert body["registration_endpoint"].endswith("/register")
+    assert "S256" in body["code_challenge_methods_supported"]
+
+
+async def test_unauthenticated_mcp_advertises_discovery(oauth_app_client) -> None:
+    """No credentials -> 401 with WWW-Authenticate pointing at the resource
+    metadata. This header is what makes clients' Connect buttons work."""
+    response = await oauth_app_client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "x"})
+    assert response.status_code == 401
+    www = response.headers.get("www-authenticate", "")
+    assert "resource_metadata" in www
+    assert "/.well-known/oauth-protected-resource/mcp" in www
+
+
+# =============================================================================
+# The full dance
+# =============================================================================
+
+
+async def test_full_oauth_flow(oauth_app_client) -> None:
+    from datetime import date, timedelta
+
+    from polar_flow_server.models.sleep import Sleep
+
+    user_id = await _seed_admin_and_user(oauth_app_client)
+    async with async_session_maker() as session:
+        session.add(
+            Sleep(
+                user_id=user_id,
+                date=date.today() - timedelta(days=1),
+                sleep_score=88,
+                total_sleep_seconds=8 * 3600,
+            )
+        )
+        await session.commit()
+
+    client_id = await _register_client(oauth_app_client)
+    verifier, challenge = _pkce()
+    code = await _authorize_and_consent(oauth_app_client, client_id, challenge)
+    tokens = await _exchange_code(oauth_app_client, client_id, code, verifier)
+    assert tokens["token_type"].lower() == "bearer"
+
+    # The issued token works for real MCP calls, scoped to the user
+    async with _bearer_mcp_client(oauth_app_client.app, tokens["access_token"]) as mcp:
+        result = await mcp.call_tool("get_sleep", {"days": 7})
+    assert not result.is_error
+    assert result.structured_content["records"][0]["sleep_score"] == 88
+
+    # Refresh rotates the pair: new tokens work, old access token is dead
+    refreshed = (
+        await oauth_app_client.post(
+            "/token",
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": tokens["refresh_token"],
+                "client_id": client_id,
+            },
+        )
+    ).json()
+    assert refreshed["access_token"] != tokens["access_token"]
+
+    old = await oauth_app_client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "method": "x"},
+        headers={"Authorization": f"Bearer {tokens['access_token']}"},
+    )
+    assert old.status_code == 401
+
+    async with _bearer_mcp_client(oauth_app_client.app, refreshed["access_token"]) as mcp:
+        result = await mcp.call_tool("get_sleep", {"days": 7})
+    assert not result.is_error
+
+    # Revocation kills the new pair too
+    # client_secret must be PRESENT even for public clients: the SDK's
+    # RevocationRequest declares it `str | None` with no default
+    revoke = await oauth_app_client.post(
+        "/revoke",
+        data={"token": refreshed["access_token"], "client_id": client_id, "client_secret": ""},
+    )
+    assert revoke.status_code == 200
+    dead = await oauth_app_client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "method": "x"},
+        headers={"Authorization": f"Bearer {refreshed['access_token']}"},
+    )
+    assert dead.status_code == 401
+
+
+async def test_authorization_code_is_single_use(oauth_app_client) -> None:
+    await _seed_admin_and_user(oauth_app_client)
+    client_id = await _register_client(oauth_app_client)
+    verifier, challenge = _pkce()
+    code = await _authorize_and_consent(oauth_app_client, client_id, challenge)
+    await _exchange_code(oauth_app_client, client_id, code, verifier)
+
+    replay = await oauth_app_client.post(
+        "/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": REDIRECT_URI,
+            "client_id": client_id,
+            "code_verifier": verifier,
+        },
+    )
+    assert replay.status_code == 400
+
+
+async def test_consent_deny_bounces_with_error(oauth_app_client) -> None:
+    await _seed_admin_and_user(oauth_app_client)
+    client_id = await _register_client(oauth_app_client)
+    _, challenge = _pkce()
+
+    response = await oauth_app_client.get(
+        "/authorize",
+        params={
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": REDIRECT_URI,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "state": "state-deny",
+        },
+        follow_redirects=False,
+    )
+    consent_url = response.headers["location"]
+    page = await oauth_app_client.get(consent_url)
+    match = re.search(r'name="_csrf_token" value="([^"]+)"', page.text)
+    req = re.search(r'name="req" value="([^"]+)"', page.text)
+    form = {"req": req.group(1), "action": "deny"}
+    if match:
+        form["_csrf_token"] = match.group(1)
+
+    denied = await oauth_app_client.post("/admin/oauth/consent", data=form, follow_redirects=False)
+    assert denied.status_code == 303
+    location = denied.headers["location"]
+    assert location.startswith(REDIRECT_URI)
+    assert "error=access_denied" in location
+    assert "state=state-deny" in location
+
+
+async def test_consent_requires_admin_login(oauth_app_client) -> None:
+    """Unauthenticated consent hits the login wall with a next redirect."""
+    response = await oauth_app_client.get(
+        "/admin/oauth/consent", params={"req": "whatever"}, follow_redirects=False
+    )
+    assert response.status_code == 303
+    assert "/admin/login?next=" in response.headers["location"]
+
+
+async def test_settings_lists_and_revokes_connected_app(oauth_app_client) -> None:
+    """Settings shows connector apps and the revoke button kills their tokens."""
+    await _seed_admin_and_user(oauth_app_client)
+    client_id = await _register_client(oauth_app_client)
+    verifier, challenge = _pkce()
+    code = await _authorize_and_consent(oauth_app_client, client_id, challenge)
+    tokens = await _exchange_code(oauth_app_client, client_id, code, verifier)
+
+    page = await oauth_app_client.get("/admin/settings")
+    assert page.status_code == 200
+    assert "Test MCP Client" in page.text
+
+    match = re.search(r'name="_csrf_token" value="([^"]+)"', page.text)
+    form = {"client_id": client_id}
+    if match:
+        form["_csrf_token"] = match.group(1)
+    revoked = await oauth_app_client.post(
+        "/admin/oauth-apps/revoke", data=form, follow_redirects=False
+    )
+    assert revoked.status_code == 303
+
+    dead = await oauth_app_client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "method": "x"},
+        headers={"Authorization": f"Bearer {tokens['access_token']}"},
+    )
+    assert dead.status_code == 401
+
+
+# =============================================================================
+# API keys still work in OAuth mode
+# =============================================================================
+
+
+async def test_api_key_header_still_works(oauth_app_client) -> None:
+    from tests.test_mcp_server import _mcp_client, _seed_user, _user_key
+
+    user_id = await _seed_user()
+    raw_key = await _user_key(user_id)
+
+    async with _mcp_client(oauth_app_client.app, raw_key) as mcp:
+        tools = await mcp.list_tools()
+    assert len(tools.tools) == 10
+
+
+async def test_api_key_as_bearer_still_works(oauth_app_client) -> None:
+    from tests.test_mcp_server import _seed_user, _user_key
+
+    user_id = await _seed_user()
+    raw_key = await _user_key(user_id)
+
+    async with _bearer_mcp_client(oauth_app_client.app, raw_key) as mcp:
+        result = await mcp.call_tool("get_sync_status", {})
+    assert not result.is_error
+    assert result.structured_content["user_id"] == user_id


### PR DESCRIPTION
The MCP endpoint becomes a first-class OAuth 2.1 citizen: add the connector in Claude Desktop / claude.ai, click **Connect**, and you land on *your server's* login + consent screen. No API keys to paste.

## How it works

- **polar-flow-server is its own authorization server.** The SDK supplies the protocol endpoints (`/authorize`, `/token`, `/register`, `/revoke`, both `.well-known` docs) and PKCE verification; this PR adds the storage-backed provider, the consent UI, and the wiring.
- **Discovery chain**: unauthenticated `/mcp` now 401s with `WWW-Authenticate` → protected-resource metadata → AS metadata → Dynamic Client Registration. That's exactly the dance Claude's Connect button performs.
- **The human half**: `/authorize` hands off to `/admin/oauth/consent` via a signed, expiring blob (no server-side pending-auth state). Admin login (with new `next` redirect support) → consent screen → single-use PKCE-bound code.
- **Tokens**: user-scoped, access 1 h, refresh rotates the whole pair, revocation kills the pair. Stored as SHA-256 hashes only. New **Settings → Connected Applications** card lists every connector app with active-token counts and one-click revoke.
- **Two modes, zero regression**: OAuth activates only when `BASE_URL` is set (self-hosted — the admin approving consent IS the data's user). Without it, `/mcp` keeps the current API-key behavior byte-for-byte; all 21 existing MCP tests pass unchanged. In OAuth mode, API keys still work (header or bearer) through the same verifier funnel.
- AS endpoints mount at the **site root** (the issuer), `/mcp` stays the resource server — per RFC 8414/9728 URL expectations.

## Storage

Three new tables (`oauth_clients`, `oauth_auth_codes`, `oauth_tokens`) + Alembic migration `g8h9i0j1k2l3`.

## Tests

10 new in `tests/test_mcp_oauth.py`, driving the complete flow over the real app: discovery documents, WWW-Authenticate advertisement, **the full dance** (DCR → authorize → login+consent → PKCE exchange → authenticated MCP tool calls with the issued bearer → refresh rotation kills the old token → revocation kills the new one), code replay rejection, consent deny bounce, login-wall redirect, Settings revoke, and API keys still working both ways in OAuth mode. 31 MCP-related tests total.

## Gotchas found

- Litestar mounts append a trailing slash to stripped paths; Starlette slash-redirects → infinite 307 loop on the metadata endpoints. Normalized in the mount.
- SDK's `RevocationRequest.client_secret` is `str | None` **with no default** — public clients must send the field explicitly (noted in the test).

## Deploy note

Needs `BASE_URL=https://<host>` in the environment to activate (HTTPS required — it becomes the OAuth issuer).