### PR TITLE
Fix OAuth consent blocked by form-action CSP

### DIFF
--- a/src/polar_flow_server/admin/routes.py
+++ b/src/polar_flow_server/admin/routes.py
@@ -746,12 +746,21 @@ async def oauth_consent_submit(
             request, "This authorization request is invalid or has expired. Retry from the app."
         )
 
+    # The hop back to the client CANNOT be a redirect response to this form
+    # POST: browsers enforce the page's form-action CSP ('self') against the
+    # whole redirect chain, so a 303 to the client's origin gets blocked.
+    # Render a self-navigating page instead - plain navigation is not
+    # subject to form-action, and it works for any client origin without
+    # loosening the CSP.
     if form_data.get("action") != "approve":
-        return Redirect(
-            path=construct_redirect_uri(
-                data["redirect_uri"], error="access_denied", state=data["state"]
-            ),
-            status_code=HTTP_303_SEE_OTHER,
+        return Template(
+            template_name="admin/oauth_redirect.html",
+            context={
+                "target": construct_redirect_uri(
+                    data["redirect_uri"], error="access_denied", state=data["state"]
+                ),
+                "denied": True,
+            },
         )
 
     user_id = await _connected_user_id(session)
@@ -761,7 +770,10 @@ async def oauth_consent_submit(
         )
 
     code = await PolarOAuthProvider().create_authorization_code(data, user_id)
-    return Redirect(path=build_consent_redirect(data, code), status_code=HTTP_303_SEE_OTHER)
+    return Template(
+        template_name="admin/oauth_redirect.html",
+        context={"target": build_consent_redirect(data, code), "denied": False},
+    )
 
 
 @post("/setup/oauth", sync_to_thread=False, status_code=HTTP_200_OK)

--- a/src/polar_flow_server/templates/admin/oauth_redirect.html
+++ b/src/polar_flow_server/templates/admin/oauth_redirect.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block title %}Returning to app - polar-flow-server{% endblock %}
+
+{% block head_extra %}
+<meta http-equiv="refresh" content="0;url={{ target }}">
+{% endblock %}
+
+{% block content %}
+<div class="max-w-md mx-auto mt-8">
+    <div class="bg-white shadow rounded-lg p-8 text-center">
+        <h1 class="text-2xl font-bold text-gray-900 mb-2">
+            {% if denied %}Access denied{% else %}Access approved{% endif %}
+        </h1>
+        <p class="text-gray-600 mb-6">Returning you to the application&hellip;</p>
+        <a href="{{ target }}"
+           class="inline-flex justify-center items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+            Continue
+        </a>
+    </div>
+</div>
+<script>window.location.replace({{ target | tojson }});</script>
+{% endblock %}

--- a/src/polar_flow_server/templates/base.html
+++ b/src/polar_flow_server/templates/base.html
@@ -36,6 +36,7 @@
             overflow-y: scroll;
         }
     </style>
+    {% block head_extra %}{% endblock %}
 </head>
 <body class="bg-gray-50 min-h-screen">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -137,13 +137,24 @@ async def _authorize_and_consent(client, client_id: str, challenge: str) -> str:
     form = {"req": req.group(1), "action": "approve"}
     if match:
         form["_csrf_token"] = match.group(1)
+    # Approval renders a self-navigating page, NOT a redirect: a 303 to the
+    # client's origin would be blocked by the form-action 'self' CSP.
     approved = await client.post("/admin/oauth/consent", data=form, follow_redirects=False)
-    assert approved.status_code == 303, approved.text
-    location = approved.headers["location"]
+    assert approved.status_code == 200, approved.text
+    location = _interstitial_target(approved.text)
     assert location.startswith(REDIRECT_URI)
     query = parse_qs(urlparse(location).query)
     assert query["state"] == ["state-123"]
     return query["code"][0]
+
+
+def _interstitial_target(html_text: str) -> str:
+    """Pull the client redirect target out of the consent interstitial."""
+    import html as html_mod
+
+    match = re.search(r'<a href="([^"]+)"', html_text)
+    assert match, "interstitial has no continue link"
+    return html_mod.unescape(match.group(1))
 
 
 async def _exchange_code(client, client_id: str, code: str, verifier: str) -> dict:
@@ -323,8 +334,8 @@ async def test_consent_deny_bounces_with_error(oauth_app_client) -> None:
         form["_csrf_token"] = match.group(1)
 
     denied = await oauth_app_client.post("/admin/oauth/consent", data=form, follow_redirects=False)
-    assert denied.status_code == 303
-    location = denied.headers["location"]
+    assert denied.status_code == 200
+    location = _interstitial_target(denied.text)
     assert location.startswith(REDIRECT_URI)
     assert "error=access_denied" in location
     assert "state=state-deny" in location


### PR DESCRIPTION
The Connect flow died at the Approve click in a real browser: browsers enforce the consent page's `form-action 'self'` CSP against the **entire redirect chain** of a form submission, so the 303 from the consent POST to the client's callback origin (Claude's) was blocked.

**Fix:** the consent POST now returns a small self-navigating interstitial (`meta refresh` + JS `location.replace` + a visible Continue link as fallback). Plain navigation isn't subject to `form-action`, it works for **any** client origin, and the CSP stays exactly as strict as it was — no origins added, nothing loosened.

Also deliberately **not** adding any edge-analytics origins to the CSP (a reverse proxy injecting beacons is the proxy's feature, not this app's concern — self-hosters shouldn't carry third-party origins in their policy). The blocked-beacon console line is cosmetic; operators who run such proxies can disable the injection at their edge.

Tests updated: approval/deny now assert the 200 interstitial and parse the client redirect target (with code/state or `error=access_denied`) out of the page. 21 OAuth+CSP tests green.