### PR TITLE
MCP Apps: 'Today at a glance' health card rendered in-conversation

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -99,6 +99,17 @@ numbers.
 Tool descriptions are written for the model — units, semantics, and when to
 use which tool — so assistants generally pick sensibly without prompting.
 
+### Rendered cards (MCP Apps)
+
+In clients that support the [MCP Apps extension](https://modelcontextprotocol.io/extensions/apps/overview)
+(claude.ai, Claude Desktop, VS Code, and others), `get_health_insights`
+renders a **Today at a glance** card right in the conversation: current
+metrics vs your personal baselines, observations, and suggestions, following
+the client's light/dark theme. The first time, the client asks permission to
+display the app. Clients without Apps support (e.g. Claude Code) simply get
+the tool's normal structured result — the card is progressive enhancement,
+never the data channel.
+
 The tool list order is stable and `tools/list` carries a one-hour cache
 hint (`ttlMs`), so client-side prompt caches stay warm across calls.
 

--- a/src/polar_flow_server/mcp_server/apps_ui.py
+++ b/src/polar_flow_server/mcp_server/apps_ui.py
@@ -1,0 +1,229 @@
+"""MCP Apps extension: rendered health cards inside the conversation.
+
+The Apps extension (io.modelcontextprotocol/ui, spec 2026-01-26) lets a tool
+carry a ``ui://`` HTML resource that capable hosts (claude.ai, Claude
+Desktop, VS Code, ...) render in a sandboxed iframe, pushing the tool's
+result in via postMessage. Hosts without the extension just use the tool's
+normal structured result - the card is progressive enhancement, never the
+data channel.
+
+The card is one self-contained HTML document (inline CSS/JS - the default
+Apps sandbox CSP allows exactly that and nothing external) themed with the
+host's CSS variables so it follows the client's light/dark automatically.
+
+Claude additionally requires a ``domain`` derived from the public /mcp URL
+("domain signing") - computed here from BASE_URL when configured.
+"""
+
+import hashlib
+
+from mcp.server.apps import Apps
+
+from polar_flow_server.core.config import settings
+
+INSIGHTS_RESOURCE_URI = "ui://polar-flow/insights-card.html"
+
+INSIGHTS_CARD_HTML = """<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Today at a glance</title>
+<style>
+  :root { color-scheme: light dark; }
+  body {
+    margin: 0;
+    font-family: var(--font-sans, system-ui, -apple-system, sans-serif);
+    color: var(--color-text-primary, light-dark(#111827, #f3f4f6));
+    background: transparent;
+  }
+  .card { padding: 16px; }
+  .head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; }
+  .title { font-size: 15px; font-weight: 600; }
+  .pill {
+    font-size: 11px; font-weight: 600; padding: 2px 10px; border-radius: 999px;
+    border: 1px solid var(--color-border-primary, light-dark(#e5e7eb, #374151));
+  }
+  .pill.ready { color: #059669; border-color: #05966955; }
+  .pill.partial { color: #d97706; border-color: #d9770655; }
+  .pill.unavailable { color: var(--color-text-secondary, #6b7280); }
+  .tiles { display: grid; grid-template-columns: repeat(auto-fit, minmax(110px, 1fr)); gap: 8px; }
+  .tile {
+    border: 1px solid var(--color-border-primary, light-dark(#e5e7eb, #374151));
+    border-radius: var(--border-radius-md, 10px); padding: 10px 12px;
+  }
+  .tile .label { font-size: 11px; color: var(--color-text-secondary, #6b7280); }
+  .tile .value { font-size: 22px; font-weight: 700; line-height: 1.3; }
+  .tile .value .unit { font-size: 11px; font-weight: 500; color: var(--color-text-secondary, #6b7280); }
+  .tile .delta { font-size: 11px; color: var(--color-text-secondary, #6b7280); }
+  .tile .delta.up { color: #059669; }
+  .tile .delta.down { color: #dc2626; }
+  .section { margin-top: 14px; }
+  .section h3 {
+    font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em;
+    color: var(--color-text-secondary, #6b7280); margin: 0 0 6px;
+  }
+  .obs { display: flex; gap: 8px; align-items: baseline; font-size: 13px; margin-bottom: 5px; }
+  .dot { width: 7px; height: 7px; border-radius: 999px; flex: none; background: #9ca3af; position: relative; top: -1px; }
+  .dot.high { background: #dc2626; }
+  .dot.medium { background: #d97706; }
+  .sugg { font-size: 13px; margin-bottom: 5px; }
+  .sugg .conf { font-size: 11px; color: var(--color-text-secondary, #6b7280); }
+  .empty { font-size: 13px; color: var(--color-text-secondary, #6b7280); padding: 8px 0; }
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="head">
+    <div class="title">Today at a glance</div>
+    <div class="pill" id="status"></div>
+  </div>
+  <div id="content"><div class="empty">Waiting for data&hellip;</div></div>
+</div>
+<script>
+(function () {
+  "use strict";
+
+  function el(tag, cls, text) {
+    var node = document.createElement(tag);
+    if (cls) node.className = cls;
+    if (text !== undefined) node.textContent = text;
+    return node;
+  }
+
+  function fmt(value, digits) {
+    if (value === null || value === undefined) return null;
+    return Number(value).toFixed(digits);
+  }
+
+  function tile(label, value, unit, comparison) {
+    var t = el("div", "tile");
+    t.appendChild(el("div", "label", label));
+    var v = el("div", "value", value === null ? "--" : value);
+    if (value !== null && unit) {
+      v.appendChild(document.createTextNode("\\u00a0"));
+      v.appendChild(el("span", "unit", unit));
+    }
+    t.appendChild(v);
+    if (comparison && comparison.percent_of_baseline !== null && comparison.percent_of_baseline !== undefined) {
+      var pct = Math.round(comparison.percent_of_baseline - 100);
+      var cls = "delta" + (pct > 2 ? " up" : pct < -2 ? " down" : "");
+      var arrow = pct > 2 ? "\\u2191" : pct < -2 ? "\\u2193" : "\\u2192";
+      t.appendChild(el("div", cls, arrow + " " + (pct > 0 ? "+" : "") + pct + "% vs baseline"));
+    }
+    return t;
+  }
+
+  function render(data) {
+    var status = (data.status || "unavailable");
+    var pill = document.getElementById("status");
+    pill.textContent = status === "ready" ? "Ready" : status === "partial" ? "Building baselines" : "Not enough data";
+    pill.className = "pill " + status;
+
+    var content = document.getElementById("content");
+    content.textContent = "";
+
+    if (status === "unavailable") {
+      content.appendChild(el("div", "empty",
+        "Only " + (data.data_age_days || 0) + " days of history so far - insights unlock at 7 days."));
+      notifySize();
+      return;
+    }
+
+    var metrics = data.current_metrics || {};
+    var baselines = data.baselines || {};
+    var tiles = el("div", "tiles");
+    tiles.appendChild(tile("HRV", fmt(metrics.hrv, 0), "ms", baselines.hrv_rmssd));
+    tiles.appendChild(tile("Sleep score", fmt(metrics.sleep_score, 0), "", baselines.sleep_score));
+    tiles.appendChild(tile("Resting HR", fmt(metrics.resting_hr, 0), "bpm", baselines.resting_hr));
+    tiles.appendChild(tile("Load ratio", fmt(metrics.training_load_ratio, 2), "", baselines.training_load_ratio));
+    content.appendChild(tiles);
+
+    var observations = (data.observations || []).slice(0, 3);
+    if (observations.length) {
+      var section = el("div", "section");
+      section.appendChild(el("h3", null, "Observations"));
+      observations.forEach(function (o) {
+        var row = el("div", "obs");
+        row.appendChild(el("span", "dot " + (o.priority || "")));
+        row.appendChild(el("span", null, o.fact + (o.context ? " (" + o.context + ")" : "")));
+        section.appendChild(row);
+      });
+      content.appendChild(section);
+    }
+
+    var suggestions = (data.suggestions || []).slice(0, 2);
+    if (suggestions.length) {
+      var section2 = el("div", "section");
+      section2.appendChild(el("h3", null, "Suggestions"));
+      suggestions.forEach(function (s) {
+        var row = el("div", "sugg");
+        row.appendChild(document.createTextNode(s.description + " "));
+        row.appendChild(el("span", "conf", Math.round((s.confidence || 0) * 100) + "% confidence"));
+        section2.appendChild(row);
+      });
+      content.appendChild(section2);
+    }
+    notifySize();
+  }
+
+  function notifySize() {
+    try {
+      window.parent.postMessage({
+        jsonrpc: "2.0",
+        method: "ui/notifications/size-changed",
+        params: { height: document.documentElement.scrollHeight }
+      }, "*");
+    } catch (e) { /* host may not support sizing - fine */ }
+  }
+
+  function extractPayload(message) {
+    var result = message && (message.result || (message.params && message.params.result));
+    if (!result) return null;
+    if (result.structuredContent) return result.structuredContent;
+    if (result.structured_content) return result.structured_content;
+    var text = result.content && result.content[0] && result.content[0].text;
+    if (text) { try { return JSON.parse(text); } catch (e) { return null; } }
+    return null;
+  }
+
+  window.addEventListener("message", function (event) {
+    var payload = extractPayload(event.data);
+    if (payload) render(payload);
+  });
+})();
+</script>
+</body>
+</html>
+"""
+
+
+def claude_ui_domain() -> str | None:
+    """Claude's "domain signing" value for our Apps resources.
+
+    Per Claude's cross-compatibility docs: sha256 of the public MCP URL,
+    first 32 hex chars, under .claudemcpcontent.com. Only computable when
+    BASE_URL is configured.
+    """
+    if not settings.base_url:
+        return None
+    public_mcp_url = f"{str(settings.base_url).rstrip('/')}/mcp"
+    digest = hashlib.sha256(public_mcp_url.encode()).hexdigest()[:32]
+    return f"{digest}.claudemcpcontent.com"
+
+
+def build_apps_extension() -> Apps:
+    """Create the Apps extension with all card resources registered.
+
+    Tools are bound to resources in ``server.py`` (via ``apps.tool``) so
+    tool registration order - the wire order - stays in one place.
+    """
+    apps = Apps()
+    apps.add_html_resource(
+        INSIGHTS_RESOURCE_URI,
+        INSIGHTS_CARD_HTML,
+        title="Today at a glance",
+        description="Health metrics vs personal baselines, observations, suggestions",
+        domain=claude_ui_domain(),
+        prefers_border=True,
+    )
+    return apps

--- a/src/polar_flow_server/mcp_server/server.py
+++ b/src/polar_flow_server/mcp_server/server.py
@@ -30,9 +30,10 @@ the watch recorded - missing dates mean the device wasn't worn.
 """
 
 # Registration order == tools/list order (the SDK preserves insertion order).
-# Keep stable; append new tools rather than reordering.
+# Keep stable; append new tools rather than reordering. get_health_insights
+# is registered separately via the Apps extension (it carries the rendered
+# "Today at a glance" card) - see build_mcp_server.
 _TOOLS = (
-    tools.get_health_insights,
     tools.get_sleep,
     tools.get_recovery,
     tools.get_activity,
@@ -55,6 +56,13 @@ def build_mcp_server(
     route with bearer auth and serves protected-resource metadata; without
     them the mount in ``asgi.py`` does API-key auth itself.
     """
+    from polar_flow_server.mcp_server.apps_ui import INSIGHTS_RESOURCE_URI, build_apps_extension
+
+    apps = build_apps_extension()
+    # get_health_insights carries the rendered card in Apps-capable hosts;
+    # everywhere else it behaves exactly like a plain tool.
+    apps.tool(resource_uri=INSIGHTS_RESOURCE_URI)(tools.get_health_insights)
+
     server = MCPServer(
         name="polar-flow-server",
         title="Polar Health Data",
@@ -63,6 +71,7 @@ def build_mcp_server(
         website_url="https://github.com/StuMason/polar-flow-server",
         token_verifier=token_verifier,
         auth=auth,
+        extensions=[apps],
         # The tool list only changes on deploy; let clients cache it. Health
         # data responses themselves are never cacheable by intermediaries.
         cache_hints={"tools/list": CacheHint(ttl_ms=3_600_000, scope="private")},

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -253,6 +253,53 @@ async def test_days_out_of_range_rejected_by_schema(app_client) -> None:
 
 
 # =============================================================================
+# MCP Apps: the "Today at a glance" card on get_health_insights
+# =============================================================================
+
+
+async def test_insights_tool_carries_apps_card(app_client) -> None:
+    """get_health_insights is bound to a ui:// resource that Apps-capable
+    hosts render; the card must be fully self-contained (sandbox CSP allows
+    inline only) and the tool must stay a normal tool everywhere else."""
+    user_id = await _seed_user()
+    raw_key = await _user_key(user_id)
+
+    async with _mcp_client(app_client.app, raw_key) as client:
+        tools = await client.list_tools()
+        insights = next(t for t in tools.tools if t.name == "get_health_insights")
+        assert insights.meta == {"ui": {"resourceUri": "ui://polar-flow/insights-card.html"}}
+
+        content = await client.read_resource("ui://polar-flow/insights-card.html")
+        card = content.contents[0]
+
+    assert card.mime_type == "text/html;profile=mcp-app"
+    html_text = card.text
+    assert "Today at a glance" in html_text
+    assert "<script>" in html_text and "<style>" in html_text
+    # Self-contained: no external fetches - the Apps sandbox would block them
+    assert 'src="http' not in html_text
+    assert "<link" not in html_text
+    # Theme via host variables so light/dark follows the client
+    assert "--color-text-primary" in html_text
+
+
+def test_claude_ui_domain_derivation(monkeypatch) -> None:
+    import hashlib
+
+    from polar_flow_server.core.config import settings
+    from polar_flow_server.mcp_server.apps_ui import claude_ui_domain
+
+    monkeypatch.setattr(settings, "base_url", None)
+    assert claude_ui_domain() is None
+
+    monkeypatch.setattr(settings, "base_url", "https://polar.example.com")
+    expected = (
+        hashlib.sha256(b"https://polar.example.com/mcp").hexdigest()[:32] + ".claudemcpcontent.com"
+    )
+    assert claude_ui_domain() == expected
+
+
+# =============================================================================
 # Slice 2 tools: activity, exercises, biosensing, baselines, patterns
 # =============================================================================
 


### PR DESCRIPTION
First MCP Apps view: `get_health_insights` now carries a `ui://` HTML resource via the official Apps extension (`io.modelcontextprotocol/ui`, spec 2026-01-26). In clients that render Apps — claude.ai, Claude Desktop, VS Code, and friends — asking "how am I doing?" produces an actual **card in the conversation**: current metrics vs personal baselines with delta arrows, prioritized observations, and suggestions with confidence. First render prompts the user to allow the app.

**Progressive enhancement, never the data channel**: clients without Apps (e.g. Claude Code) get the tool's normal structured result, unchanged. Tool wire order is unchanged too — insights stays first (verified by the pinned order test).

Implementation notes:
- One self-contained HTML document, inline CSS/JS only — exactly what the Apps sandbox default CSP allows. No external fetches (asserted by test).
- Themed with the host's CSS custom properties (`--color-*`, `--font-sans`, `--border-radius-*`) with sane fallbacks, so light/dark follows the client automatically.
- Reads the tool result from the host's postMessage bridge (`structuredContent`, with text-content fallback), renders tiles/observations/suggestions, and reports its height via `ui/notifications/size-changed` for auto-sizing.
- Claude's **domain signing** derived from `BASE_URL` (`sha256(<public /mcp URL>)[:32].claudemcpcontent.com`), per their cross-compatibility docs.
- Empty-history state handled ("insights unlock at 7 days").

Tests: card binding meta + resource MIME (`text/html;profile=mcp-app`) + self-containment + theming variables asserted through the SDK client over the real app; domain derivation unit-tested. 33 MCP tests green.

**Known risk, flagged**: there's an open upstream report (ext-apps #671) of remote custom connectors falling back to text in Claude despite correct negotiation. The real-browser render in Claude Desktop is the acceptance test once deployed.