### PR TITLE
Fix Apps card render (bridge handshake) + field-test data-quality bugs

### DIFF
--- a/alembic/versions/h9i0j1k2l3m4_null_zero_hr_aggregates.py
+++ b/alembic/versions/h9i0j1k2l3m4_null_zero_hr_aggregates.py
@@ -1,0 +1,33 @@
+"""Null physiologically-impossible zero HR aggregates from old syncs.
+
+The continuous-HR transformer now excludes zero/no-signal samples before
+computing min/avg/max, but rows synced before that fix still carry
+hr_min = 0 (a dead person's resting heart rate). Heal them in place -
+zero means "no valid samples", i.e. NULL.
+
+Revision ID: h9i0j1k2l3m4
+Revises: g8h9i0j1k2l3
+Create Date: 2026-08-05 09:30:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "h9i0j1k2l3m4"
+down_revision: str | None = "g8h9i0j1k2l3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Replace zero HR aggregates with NULL."""
+    op.execute("UPDATE continuous_heart_rate SET hr_min = NULL WHERE hr_min = 0")
+    op.execute("UPDATE continuous_heart_rate SET hr_avg = NULL WHERE hr_avg = 0")
+    op.execute("UPDATE continuous_heart_rate SET hr_max = NULL WHERE hr_max = 0")
+
+
+def downgrade() -> None:
+    """Irreversible data fix - zeros were noise, not data."""

--- a/src/polar_flow_server/mcp_server/apps_ui.py
+++ b/src/polar_flow_server/mcp_server/apps_ui.py
@@ -176,20 +176,51 @@ INSIGHTS_CARD_HTML = """<!doctype html>
     } catch (e) { /* host may not support sizing - fine */ }
   }
 
-  function extractPayload(message) {
-    var result = message && (message.result || (message.params && message.params.result));
-    if (!result) return null;
-    if (result.structuredContent) return result.structuredContent;
-    if (result.structured_content) return result.structured_content;
-    var text = result.content && result.content[0] && result.content[0].text;
+  function extractPayload(container) {
+    if (!container) return null;
+    if (container.structuredContent) return container.structuredContent;
+    if (container.structured_content) return container.structured_content;
+    var text = container.content && container.content[0] && container.content[0].text;
     if (text) { try { return JSON.parse(text); } catch (e) { return null; } }
     return null;
   }
 
+  // The MCP Apps bridge (spec 2026-01-26): the HOST WAITS for the view to
+  // complete the ui/initialize handshake before it delivers any tool data.
+  // A view that only listens renders forever-blank.
+  var INIT_ID = 1;
   window.addEventListener("message", function (event) {
-    var payload = extractPayload(event.data);
-    if (payload) render(payload);
+    var msg = event.data;
+    if (!msg || msg.jsonrpc !== "2.0") return;
+
+    if (msg.id === INIT_ID && msg.result) {
+      // Handshake step 3: confirm readiness; host then sends tool-result
+      window.parent.postMessage({ jsonrpc: "2.0", method: "ui/notifications/initialized" }, "*");
+      return;
+    }
+
+    if (msg.method === "ui/notifications/tool-result" && msg.params) {
+      var payload = extractPayload(msg.params);
+      if (payload) render(payload);
+      return;
+    }
+
+    // Lenient fallback for hosts that push a bare CallToolResult
+    var legacy = extractPayload(msg.result || (msg.params && msg.params.result));
+    if (legacy) render(legacy);
   });
+
+  // Handshake step 1: announce ourselves
+  window.parent.postMessage({
+    jsonrpc: "2.0",
+    id: INIT_ID,
+    method: "ui/initialize",
+    params: {
+      appCapabilities: { availableDisplayModes: ["inline"] },
+      clientInfo: { name: "polar-today-at-a-glance", version: "1.0.0" },
+      protocolVersion: "2026-01-26"
+    }
+  }, "*");
 })();
 </script>
 </body>

--- a/src/polar_flow_server/mcp_server/asgi.py
+++ b/src/polar_flow_server/mcp_server/asgi.py
@@ -46,6 +46,13 @@ def create_mcp_mount(server: MCPServer, *, oauth_enabled: bool = False) -> ASGIR
     """Build the ``/mcp`` mount for a Litestar app."""
     mcp_asgi = server.streamable_http_app(
         streamable_http_path="/",
+        # Legacy (2025-protocol) clients like Claude Desktop otherwise mint a
+        # server-side session per request cycle that is never cleaned up -
+        # unbounded memory growth between deploys. Stateless mode strips that
+        # for legacy clients only (2026-07-28 clients are sessionless by
+        # construction), and none of our tools use the server-to-client
+        # back-channel that sessions would enable.
+        stateless_http=True,
         # Host-header (DNS-rebinding) checks default to localhost-only and
         # would 421 behind the reverse proxy. Rebinding attacks are moot
         # here anyway: every request must carry a credential a rebound

--- a/src/polar_flow_server/mcp_server/tools.py
+++ b/src/polar_flow_server/mcp_server/tools.py
@@ -93,10 +93,12 @@ async def get_sleep(days: DaysParam = 30, user_id: UserIdParam = None) -> dict[s
             .order_by(Sleep.date.desc())
         )
         records = result.scalars().all()
+        staleness = await _most_recent_hint(session, Sleep, Sleep.date, uid) if not records else {}
 
     return {
         "days": days,
         "count": len(records),
+        **staleness,
         "records": [
             {
                 "date": str(r.date),
@@ -147,9 +149,15 @@ async def get_recovery(days: DaysParam = 30, user_id: UserIdParam = None) -> dic
             .order_by(CardioLoad.date.desc())
         )
         cardio = cardio_result.scalars().all()
+        staleness = (
+            await _most_recent_hint(session, NightlyRecharge, NightlyRecharge.date, uid)
+            if not recharge and not cardio
+            else {}
+        )
 
     return {
         "days": days,
+        **staleness,
         "nightly_recharge": [
             {
                 "date": str(r.date),
@@ -197,10 +205,14 @@ async def get_activity(days: DaysParam = 30, user_id: UserIdParam = None) -> dic
             .order_by(Activity.date.desc())
         )
         records = result.scalars().all()
+        staleness = (
+            await _most_recent_hint(session, Activity, Activity.date, uid) if not records else {}
+        )
 
     return {
         "days": days,
         "count": len(records),
+        **staleness,
         "records": [
             {
                 "date": str(r.date),
@@ -239,7 +251,9 @@ async def get_exercises(
     heart rate (bpm), and training load. With `exercise_id`: every recorded
     metric for that single workout, including speed (m/s), cadence, power
     (watts), and elevation. Training load is Polar's cardio strain estimate
-    for the session - compare against get_recovery's tolerance.
+    for the session - compare against get_recovery's tolerance. Calories are
+    null when the device reported an implausibly low value for the duration
+    (sensor noise, e.g. no HR strap) - null means unmeasured, not zero burn.
     """
     uid = await resolve_scoped_user_id(user_id)
 
@@ -260,7 +274,7 @@ async def get_exercises(
             "sport": r.sport,
             "duration_seconds": r.duration_seconds,
             "distance_meters": r.distance_meters,
-            "calories": r.calories,
+            "calories": _plausible_calories(r.calories, r.duration_seconds),
             "average_heart_rate_bpm": r.average_heart_rate,
             "max_heart_rate_bpm": r.max_heart_rate,
             "average_speed_mps": r.average_speed_mps,
@@ -283,10 +297,16 @@ async def get_exercises(
             .order_by(Exercise.start_time.desc())
         )
         records = result.scalars().all()
+        staleness = (
+            await _most_recent_hint(session, Exercise, Exercise.start_time, uid)
+            if not records
+            else {}
+        )
 
     return {
         "days": days,
         "count": len(records),
+        **staleness,
         "records": [
             {
                 "id": r.id,
@@ -296,7 +316,7 @@ async def get_exercises(
                     round(r.duration_seconds / 60, 1) if r.duration_seconds else None
                 ),
                 "distance_km": round(r.distance_meters / 1000, 2) if r.distance_meters else None,
-                "calories": r.calories,
+                "calories": _plausible_calories(r.calories, r.duration_seconds),
                 "average_heart_rate_bpm": r.average_heart_rate,
                 "max_heart_rate_bpm": r.max_heart_rate,
                 "training_load": r.training_load,
@@ -344,8 +364,12 @@ async def get_biosensing(
     since = date.today() - timedelta(days=days)
     async with async_session_maker() as session:
         records = await _query_biosensing(session, metric, uid, since)
+        staleness: dict[str, Any] = {}
+        if not records:
+            model, time_column = _BIOSENSING_TIME_COLUMNS[metric]
+            staleness = await _most_recent_hint(session, model, time_column, uid)
 
-    return {"metric": metric, "days": days, "count": len(records), "records": records}
+    return {"metric": metric, "days": days, "count": len(records), **staleness, "records": records}
 
 
 async def get_baselines(user_id: UserIdParam = None) -> dict[str, Any]:
@@ -570,6 +594,18 @@ async def _run_background_sync(uid: str, polar_token: str) -> None:
         structlog.get_logger().exception("MCP-triggered sync failed before logging", user_id=uid)
 
 
+# (model, time column) per biosensing metric - used for staleness hints
+_BIOSENSING_TIME_COLUMNS: dict[str, tuple[Any, Any]] = {
+    "spo2": (SpO2, SpO2.test_time),
+    "ecg": (ECG, ECG.test_time),
+    "body_temperature": (BodyTemperature, BodyTemperature.start_time),
+    "skin_temperature": (SkinTemperature, SkinTemperature.sleep_date),
+    "heart_rate": (ContinuousHeartRate, ContinuousHeartRate.date),
+    "alertness": (SleepWiseAlertness, SleepWiseAlertness.period_start_time),
+    "bedtime": (SleepWiseBedtime, SleepWiseBedtime.period_start_time),
+}
+
+
 async def _query_biosensing(
     session: Any, metric: str, uid: str, since: date
 ) -> list[dict[str, Any]]:
@@ -652,9 +688,10 @@ async def _query_biosensing(
         return [
             {
                 "date": str(r.date),
-                "hr_min_bpm": r.hr_min,
-                "hr_avg_bpm": r.hr_avg,
-                "hr_max_bpm": r.hr_max,
+                # zero = no valid samples that day, never a real heart rate
+                "hr_min_bpm": r.hr_min or None,
+                "hr_avg_bpm": r.hr_avg or None,
+                "hr_max_bpm": r.hr_max or None,
                 "sample_count": r.sample_count,
             }
             for r in rows.scalars().all()
@@ -703,3 +740,40 @@ async def _query_biosensing(
 def _hours(seconds: int | None) -> float | None:
     """Convert a seconds count to hours rounded to 2 decimals."""
     return round(seconds / 3600, 2) if seconds else None
+
+
+def _plausible_calories(calories: int | None, duration_seconds: int | None) -> int | None:
+    """Null out implausibly low calorie readings.
+
+    Polar occasionally reports 0/2/8 kcal for long sessions (sensor noise or
+    missing HR). Below ~1 kcal per 10 minutes of recorded duration the value
+    is noise, not measurement - surface None so agents don't report it.
+    """
+    if calories is None or not duration_seconds:
+        return calories
+    if calories < duration_seconds / 600:
+        return None
+    return calories
+
+
+async def _most_recent_hint(session: Any, model: Any, time_column: Any, uid: str) -> dict[str, Any]:
+    """Staleness hint for an empty windowed result (data can be months old).
+
+    Without this, an agent calling with the default window against a stale
+    dataset sees an empty list and concludes there is no data at all.
+    """
+    latest = (
+        await session.execute(
+            select(time_column).where(model.user_id == uid).order_by(time_column.desc()).limit(1)
+        )
+    ).scalar()
+    if latest is None:
+        return {"hint": "No records exist for this user yet."}
+    return {
+        "most_recent_record": str(latest),
+        "hint": (
+            f"No records in the requested window, but data exists up to {latest}. "
+            "Increase `days` to reach it, and consider checking get_sync_status "
+            "for staleness."
+        ),
+    }

--- a/src/polar_flow_server/services/insights.py
+++ b/src/polar_flow_server/services/insights.py
@@ -266,11 +266,13 @@ class InsightsService:
         rhr_result = await self.session.execute(rhr_stmt)
         resting_hr = rhr_result.scalar()
 
-        # Get most recent training load ratio
+        # Get most recent training load ratio. Polar emits -1.0 as a "not
+        # available" sentinel - it must never surface as a current value.
         ratio_stmt = (
             select(CardioLoad.cardio_load_ratio)
             .where(CardioLoad.user_id == user_id)
             .where(CardioLoad.cardio_load_ratio.isnot(None))
+            .where(CardioLoad.cardio_load_ratio > 0)
             .order_by(CardioLoad.date.desc())
             .limit(1)
         )
@@ -347,9 +349,13 @@ class InsightsService:
                 .limit(1)
             )
         elif metric_name == "training_load_ratio":
+            # Polar emits -1.0 as a "not available" sentinel; the baseline
+            # calc already excludes it (> 0) so the current value must too,
+            # or percent_of_baseline turns into nonsense like -131%.
             stmt = (
                 select(CardioLoad.cardio_load_ratio)
                 .where(CardioLoad.user_id == user_id)
+                .where(CardioLoad.cardio_load_ratio > 0)
                 .order_by(CardioLoad.date.desc())
                 .limit(1)
             )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -281,6 +281,11 @@ async def test_insights_tool_carries_apps_card(app_client) -> None:
     assert "<link" not in html_text
     # Theme via host variables so light/dark follows the client
     assert "--color-text-primary" in html_text
+    # The bridge handshake: hosts WAIT for ui/initialize before delivering
+    # tool results - a listen-only card renders forever-blank (field-tested)
+    assert "ui/initialize" in html_text
+    assert "ui/notifications/initialized" in html_text
+    assert "ui/notifications/tool-result" in html_text
 
 
 def test_claude_ui_domain_derivation(monkeypatch) -> None:
@@ -447,6 +452,124 @@ async def test_get_baselines_and_patterns_after_analysis(app_client) -> None:
     pattern_names = {p["pattern_name"] for p in payload["patterns"]}
     assert "hrv_trend" in pattern_names
     assert "anomaly_count" in payload
+
+
+# =============================================================================
+# Data-quality guards (from the 2026-08-05 field test report)
+# =============================================================================
+
+
+async def test_zero_hr_aggregates_serialized_as_null(app_client) -> None:
+    """hr_min 0 is a no-signal artifact, never a heart rate (BUG-1)."""
+    from polar_flow_server.models.continuous_hr import ContinuousHeartRate
+
+    user_id = await _seed_user()
+    async with async_session_maker() as session:
+        session.add(
+            ContinuousHeartRate(
+                user_id=user_id,
+                date=date.today() - timedelta(days=1),
+                hr_min=0,
+                hr_avg=0,
+                hr_max=0,
+                sample_count=12,
+            )
+        )
+        await session.commit()
+    raw_key = await _user_key(user_id)
+
+    async with _mcp_client(app_client.app, raw_key) as client:
+        result = await client.call_tool("get_biosensing", {"metric": "heart_rate", "days": 7})
+
+    record = result.structured_content["records"][0]
+    assert record["hr_min_bpm"] is None
+    assert record["hr_avg_bpm"] is None
+    assert record["hr_max_bpm"] is None
+
+
+async def test_implausible_calories_nulled(app_client) -> None:
+    """0/2/8 kcal on a long session is sensor noise, not measurement (BUG-2)."""
+    from datetime import UTC, datetime
+
+    from polar_flow_server.models.exercise import Exercise
+
+    user_id = await _seed_user()
+    async with async_session_maker() as session:
+        session.add(
+            Exercise(
+                user_id=user_id,
+                polar_exercise_id="ex-noise",
+                start_time=datetime.now(UTC) - timedelta(days=1),
+                sport="STRENGTH_TRAINING",
+                duration_seconds=166 * 60,
+                calories=0,
+            )
+        )
+        session.add(
+            Exercise(
+                user_id=user_id,
+                polar_exercise_id="ex-short",
+                start_time=datetime.now(UTC) - timedelta(days=2),
+                sport="RUNNING",
+                duration_seconds=5 * 60,
+                calories=30,
+            )
+        )
+        await session.commit()
+    raw_key = await _user_key(user_id)
+
+    async with _mcp_client(app_client.app, raw_key) as client:
+        result = await client.call_tool("get_exercises", {"days": 7})
+
+    by_sport = {r["sport"]: r for r in result.structured_content["records"]}
+    assert by_sport["STRENGTH_TRAINING"]["calories"] is None  # 0 kcal over 166 min
+    assert by_sport["RUNNING"]["calories"] == 30  # plausible short session kept
+
+
+async def test_empty_window_carries_staleness_hint(app_client) -> None:
+    """Stale data + default window must not read as 'no data at all' (BUG-5)."""
+    user_id = await _seed_user()
+    async with async_session_maker() as session:
+        from polar_flow_server.models.sleep import Sleep
+
+        session.add(Sleep(user_id=user_id, date=date.today() - timedelta(days=100), sleep_score=75))
+        await session.commit()
+    raw_key = await _user_key(user_id)
+
+    async with _mcp_client(app_client.app, raw_key) as client:
+        result = await client.call_tool("get_sleep", {"days": 7})
+
+    payload = result.structured_content
+    assert payload["count"] == 0
+    assert str(date.today() - timedelta(days=100)) in payload["most_recent_record"]
+    assert "Increase `days`" in payload["hint"]
+
+
+async def test_sentinel_load_ratio_excluded_from_insights(app_client) -> None:
+    """Polar's -1.0 'not available' ratio must never reach percent math (BUG-4)."""
+    from polar_flow_server.models.cardio_load import CardioLoad
+
+    user_id = await _seed_user()
+    async with async_session_maker() as session:
+        session.add(
+            CardioLoad(user_id=user_id, date=date.today(), cardio_load=0.0, cardio_load_ratio=-1.0)
+        )
+        session.add(
+            CardioLoad(
+                user_id=user_id,
+                date=date.today() - timedelta(days=1),
+                cardio_load=45.0,
+                cardio_load_ratio=1.1,
+            )
+        )
+        await session.commit()
+    raw_key = await _user_key(user_id)
+
+    async with _mcp_client(app_client.app, raw_key) as client:
+        result = await client.call_tool("get_health_insights", {})
+
+    ratio = result.structured_content["current_metrics"]["training_load_ratio"]
+    assert ratio == 1.1  # the latest REAL value, not the -1.0 sentinel
 
 
 # =============================================================================


### PR DESCRIPTION
Fixes everything actionable from the 2026-08-05 field-test report, plus the real reason the Apps card never rendered.

## The card (the render blocker)

The Apps bridge spec makes the **host wait** for the view to complete the `ui/initialize` handshake (`ui/initialize` → response → `ui/notifications/initialized`) before delivering `ui/notifications/tool-result`. Our card only *listened* — so Claude drew the iframe and both sides waited forever. The card now performs the full handshake and reads `params.structuredContent` (with content-text and legacy fallbacks). Handshake presence is asserted in tests.

## Data quality (report BUGs 1/2/4/5)

- **BUG-1** `hr_min_bpm: 0`: zero aggregates are no-signal artifacts — nulled at read time, plus migration `h9i0j1k2l3m4` heals rows synced before the transformer's zero-sample filter existed.
- **BUG-2** garbage calories: values below ~1 kcal per 10 min of duration (0 kcal / 166-min sessions) surface as `null`; plausible small values on short sessions are kept. Rule documented in the tool description so agents read null as "unmeasured".
- **BUG-4** `-1.0` sentinel → `-131%`: **both** insight read paths (`current_metrics` and baseline comparisons) now filter `cardio_load_ratio > 0`, matching the filter the baseline *calculation* always had. The test seeds a sentinel-latest row and asserts the previous real value wins.
- **BUG-5** empty default windows on stale data: empty results now include `most_recent_record` + a hint telling the agent data exists further back and to widen `days` / check `get_sync_status`.

## Not bugs (verified, no change)

- **BUG-6** `already_running`: covered by an existing test that holds the sync slot open — live syncs are just too fast to observe the branch.
- **BUG-3** "pipeline only refreshing cardio_load": prod logs show all 13 endpoints completing cleanly with 0 records — the watch hasn't uploaded to Polar cloud since early June. `cardio_load` only looks fresh because Polar generates that daily series server-side regardless. Operator action (sync the watch in Polar Flow), not code.

## Tests

5 new (37 MCP-related green): zero-HR nulling, calorie plausibility both ways, staleness hint, sentinel exclusion, handshake markers in the card HTML.