### PR TITLE
Capture dropped sleep & recharge detail (#77)

### DIFF
--- a/alembic/versions/i0j1k2l3m4n5_capture_sleep_recharge_detail.py
+++ b/alembic/versions/i0j1k2l3m4n5_capture_sleep_recharge_detail.py
@@ -15,6 +15,7 @@ Create Date: 2026-08-05 12:00:00.000000
 from collections.abc import Sequence
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/alembic/versions/i0j1k2l3m4n5_capture_sleep_recharge_detail.py
+++ b/alembic/versions/i0j1k2l3m4n5_capture_sleep_recharge_detail.py
@@ -46,9 +46,7 @@ def upgrade() -> None:
     )
     op.add_column("nightly_recharge", sa.Column("beat_to_beat_avg", sa.Integer(), nullable=True))
     op.add_column("nightly_recharge", sa.Column("hrv_samples_json", sa.Text(), nullable=True))
-    op.add_column(
-        "nightly_recharge", sa.Column("breathing_samples_json", sa.Text(), nullable=True)
-    )
+    op.add_column("nightly_recharge", sa.Column("breathing_samples_json", sa.Text(), nullable=True))
 
 
 def downgrade() -> None:

--- a/alembic/versions/i0j1k2l3m4n5_capture_sleep_recharge_detail.py
+++ b/alembic/versions/i0j1k2l3m4n5_capture_sleep_recharge_detail.py
@@ -1,0 +1,80 @@
+"""Capture rich sleep & recharge fields the API returns (issue #77).
+
+Sleep gains device/structure scalars (continuity, cycles, sleep charge,
+goal, group scores, interruption split) plus the overnight hypnogram and
+heart-rate sample series as JSON. Nightly recharge gains the overall
+recovery status, beat-to-beat average and the 5-minute HRV/breathing
+series as JSON.
+
+Revision ID: i0j1k2l3m4n5
+Revises: h9i0j1k2l3m4
+Create Date: 2026-08-05 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "i0j1k2l3m4n5"
+down_revision: str | None = "h9i0j1k2l3m4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add sleep & recharge detail columns."""
+    op.add_column("sleep", sa.Column("device_id", sa.String(50), nullable=True))
+    op.add_column("sleep", sa.Column("continuity", sa.Float(), nullable=True))
+    op.add_column("sleep", sa.Column("continuity_class", sa.Integer(), nullable=True))
+    op.add_column("sleep", sa.Column("sleep_cycles", sa.Integer(), nullable=True))
+    op.add_column("sleep", sa.Column("unrecognized_sleep_seconds", sa.Integer(), nullable=True))
+    op.add_column("sleep", sa.Column("short_interruption_seconds", sa.Integer(), nullable=True))
+    op.add_column("sleep", sa.Column("long_interruption_seconds", sa.Integer(), nullable=True))
+    op.add_column("sleep", sa.Column("sleep_charge", sa.Integer(), nullable=True))
+    op.add_column("sleep", sa.Column("sleep_goal_seconds", sa.Integer(), nullable=True))
+    op.add_column("sleep", sa.Column("group_duration_score", sa.Float(), nullable=True))
+    op.add_column("sleep", sa.Column("group_solidity_score", sa.Float(), nullable=True))
+    op.add_column("sleep", sa.Column("group_regeneration_score", sa.Float(), nullable=True))
+    op.add_column("sleep", sa.Column("hypnogram_json", sa.Text(), nullable=True))
+    op.add_column("sleep", sa.Column("heart_rate_samples_json", sa.Text(), nullable=True))
+
+    op.add_column(
+        "nightly_recharge", sa.Column("nightly_recharge_status", sa.Integer(), nullable=True)
+    )
+    op.add_column("nightly_recharge", sa.Column("beat_to_beat_avg", sa.Integer(), nullable=True))
+    op.add_column("nightly_recharge", sa.Column("hrv_samples_json", sa.Text(), nullable=True))
+    op.add_column(
+        "nightly_recharge", sa.Column("breathing_samples_json", sa.Text(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    """Drop sleep & recharge detail columns."""
+    for col in (
+        "device_id",
+        "continuity",
+        "continuity_class",
+        "sleep_cycles",
+        "unrecognized_sleep_seconds",
+        "short_interruption_seconds",
+        "long_interruption_seconds",
+        "sleep_charge",
+        "sleep_goal_seconds",
+        "group_duration_score",
+        "group_solidity_score",
+        "group_regeneration_score",
+        "hypnogram_json",
+        "heart_rate_samples_json",
+    ):
+        op.drop_column("sleep", col)
+
+    for col in (
+        "nightly_recharge_status",
+        "beat_to_beat_avg",
+        "hrv_samples_json",
+        "breathing_samples_json",
+    ):
+        op.drop_column("nightly_recharge", col)

--- a/src/polar_flow_server/api/data.py
+++ b/src/polar_flow_server/api/data.py
@@ -134,6 +134,8 @@ async def get_recharge_list(
             "ans_charge_status": r.ans_charge_status,
             "breathing_rate_avg": r.breathing_rate_avg,
             "heart_rate_avg": r.heart_rate_avg,
+            "nightly_recharge_status": r.nightly_recharge_status,
+            "beat_to_beat_avg": r.beat_to_beat_avg,
         }
         for r in records
     ]

--- a/src/polar_flow_server/api/sleep.py
+++ b/src/polar_flow_server/api/sleep.py
@@ -1,7 +1,8 @@
 """Sleep data API endpoints."""
 
+import json
 from datetime import date, timedelta
-from typing import Annotated
+from typing import Annotated, Any
 
 from litestar import Router, get
 from litestar.openapi.spec import Example
@@ -92,7 +93,7 @@ async def get_sleep_by_date(
         ),
     ],
     session: AsyncSession,
-) -> dict[str, str | int | float | None] | None:
+) -> dict[str, Any] | None:
     """Get sleep data for a specific date.
 
     Args:
@@ -147,6 +148,26 @@ async def get_sleep_by_date(
         "heart_rate_max": record.heart_rate_max,
         "breathing_rate_avg": record.breathing_rate_avg,
         "skin_temperature_avg": record.skin_temperature_avg,
+        "device_id": record.device_id,
+        "continuity": record.continuity,
+        "continuity_class": record.continuity_class,
+        "sleep_cycles": record.sleep_cycles,
+        "unrecognized_sleep_seconds": record.unrecognized_sleep_seconds,
+        "short_interruption_seconds": record.short_interruption_seconds,
+        "long_interruption_seconds": record.long_interruption_seconds,
+        "sleep_charge": record.sleep_charge,
+        "sleep_goal_hours": (
+            record.sleep_goal_seconds / 3600 if record.sleep_goal_seconds else None
+        ),
+        "group_duration_score": record.group_duration_score,
+        "group_solidity_score": record.group_solidity_score,
+        "group_regeneration_score": record.group_regeneration_score,
+        # Overnight series: time -> sleep stage (0=awake, 1=light, 3=deep, 4=REM)
+        "hypnogram": json.loads(record.hypnogram_json) if record.hypnogram_json else None,
+        # Overnight series: time -> bpm (~5 minute intervals)
+        "heart_rate_samples": (
+            json.loads(record.heart_rate_samples_json) if record.heart_rate_samples_json else None
+        ),
     }
 
 

--- a/src/polar_flow_server/mcp_server/tools.py
+++ b/src/polar_flow_server/mcp_server/tools.py
@@ -112,8 +112,14 @@ async def get_sleep(days: DaysParam = 30, user_id: UserIdParam = None) -> dict[s
                 "interruptions_hours": _hours(r.interruptions_seconds),
                 "hrv_avg_ms": r.hrv_avg,
                 "heart_rate_avg_bpm": r.heart_rate_avg,
+                "heart_rate_min_bpm": r.heart_rate_min,
+                "heart_rate_max_bpm": r.heart_rate_max,
                 "breathing_rate_avg": r.breathing_rate_avg,
                 "skin_temperature_avg": r.skin_temperature_avg,
+                "continuity_score": r.continuity,
+                "sleep_cycles": r.sleep_cycles,
+                "sleep_charge": r.sleep_charge,
+                "regeneration_score": r.group_regeneration_score,
             }
             for r in records
         ],
@@ -163,7 +169,9 @@ async def get_recovery(days: DaysParam = 30, user_id: UserIdParam = None) -> dic
                 "date": str(r.date),
                 "ans_charge": r.ans_charge,
                 "ans_charge_status": r.ans_charge_status,
+                "nightly_recharge_status": r.nightly_recharge_status,
                 "hrv_avg_ms": r.hrv_avg,
+                "beat_to_beat_avg_ms": r.beat_to_beat_avg,
                 "breathing_rate_avg": r.breathing_rate_avg,
                 "heart_rate_avg_bpm": r.heart_rate_avg,
             }

--- a/src/polar_flow_server/models/recharge.py
+++ b/src/polar_flow_server/models/recharge.py
@@ -3,7 +3,7 @@
 from datetime import date
 from typing import Any
 
-from sqlalchemy import Date, Float, Integer, String, UniqueConstraint
+from sqlalchemy import Date, Float, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from polar_flow_server.models.base import Base, TimestampMixin, UserScopedMixin, generate_uuid
@@ -55,6 +55,22 @@ class NightlyRecharge(Base, UserScopedMixin, TimestampMixin):
     sleep_score: Mapped[int | None] = mapped_column(Integer)
     sleep_charge: Mapped[float | None] = mapped_column(Float)
     sleep_charge_status: Mapped[int | None] = mapped_column(Integer)
+
+    # Overall recovery + beat-to-beat detail
+    nightly_recharge_status: Mapped[int | None] = mapped_column(
+        Integer, comment="Overall recovery status 1-6 (1=compromised, 6=excellent)"
+    )
+    beat_to_beat_avg: Mapped[int | None] = mapped_column(
+        Integer, comment="Average milliseconds between heartbeats (0 = no signal -> NULL)"
+    )
+
+    # Raw overnight 5-minute series stored as JSON for detailed analysis
+    hrv_samples_json: Mapped[str | None] = mapped_column(
+        Text, comment="JSON time->HRV ms mapping, 5 minute averages"
+    )
+    breathing_samples_json: Mapped[str | None] = mapped_column(
+        Text, comment="JSON time->breaths/min mapping, 5 minute averages"
+    )
 
     def __repr__(self) -> str:
         """String representation."""

--- a/src/polar_flow_server/models/sleep.py
+++ b/src/polar_flow_server/models/sleep.py
@@ -3,7 +3,7 @@
 from datetime import date
 from typing import Any
 
-from sqlalchemy import Date, Float, Integer, String, UniqueConstraint
+from sqlalchemy import Date, Float, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from polar_flow_server.models.base import Base, TimestampMixin, UserScopedMixin, generate_uuid
@@ -61,6 +61,36 @@ class Sleep(Base, UserScopedMixin, TimestampMixin):
 
     # Temperature
     skin_temperature_avg: Mapped[float | None] = mapped_column(Float)
+
+    # Device & sleep structure
+    device_id: Mapped[str | None] = mapped_column(String(50), comment="Recording device ID")
+    continuity: Mapped[float | None] = mapped_column(
+        Float, comment="Sleep continuity score 1.0-5.0 (Polar sends 0 for no data -> NULL)"
+    )
+    continuity_class: Mapped[int | None] = mapped_column(
+        Integer, comment="Continuity classification 1-5"
+    )
+    sleep_cycles: Mapped[int | None] = mapped_column(Integer, comment="Number of sleep cycles")
+    unrecognized_sleep_seconds: Mapped[int | None] = mapped_column(
+        Integer, comment="Unrecognized sleep stage duration"
+    )
+    short_interruption_seconds: Mapped[int | None] = mapped_column(Integer)
+    long_interruption_seconds: Mapped[int | None] = mapped_column(Integer)
+    sleep_charge: Mapped[int | None] = mapped_column(
+        Integer, comment="Sleep charge score 1-100 (Polar sends -1 for unavailable -> NULL)"
+    )
+    sleep_goal_seconds: Mapped[int | None] = mapped_column(Integer, comment="User's sleep goal")
+    group_duration_score: Mapped[float | None] = mapped_column(Float, comment="0-100")
+    group_solidity_score: Mapped[float | None] = mapped_column(Float, comment="0-100")
+    group_regeneration_score: Mapped[float | None] = mapped_column(Float, comment="0-100")
+
+    # Raw overnight series stored as JSON for detailed analysis
+    hypnogram_json: Mapped[str | None] = mapped_column(
+        Text, comment="JSON time->stage mapping (0=awake, 1=light, 3=deep, 4=REM)"
+    )
+    heart_rate_samples_json: Mapped[str | None] = mapped_column(
+        Text, comment="JSON time->bpm mapping, ~5 minute intervals"
+    )
 
     def __repr__(self) -> str:
         """String representation."""

--- a/src/polar_flow_server/transformers/recharge.py
+++ b/src/polar_flow_server/transformers/recharge.py
@@ -5,6 +5,7 @@ Converts polar-flow SDK NightlyRecharge model to database-ready dictionary.
 
 from __future__ import annotations
 
+import json
 from datetime import date as date_type
 from typing import TYPE_CHECKING, Any
 
@@ -24,6 +25,9 @@ class RechargeTransformer:
     - heart_rate_variability_avg -> hrv_avg (RENAMED!)
     - breathing_rate_avg -> breathing_rate_avg
     - heart_rate_avg -> heart_rate_avg
+    - nightly_recharge_status -> nightly_recharge_status
+    - beat_to_beat_avg -> beat_to_beat_avg (0 = no signal -> NULL)
+    - hrv_samples / breathing_samples -> *_samples_json
 
     Note: SDK doesn't provide these database fields:
     - hrv_status, breathing_rate_status, heart_rate_status
@@ -55,7 +59,19 @@ class RechargeTransformer:
             "hrv_avg": sdk_recharge.heart_rate_variability_avg,
             "breathing_rate_avg": sdk_recharge.breathing_rate_avg,
             "heart_rate_avg": sdk_recharge.heart_rate_avg,
-            # SDK doesn't provide status fields or sleep metrics
+            "nightly_recharge_status": sdk_recharge.nightly_recharge_status,
+            # Zero milliseconds between beats means "no signal", not data
+            "beat_to_beat_avg": sdk_recharge.beat_to_beat_avg or None,
+            # Overnight 5-minute series
+            "hrv_samples_json": (
+                json.dumps(sdk_recharge.hrv_samples) if sdk_recharge.hrv_samples else None
+            ),
+            "breathing_samples_json": (
+                json.dumps(sdk_recharge.breathing_samples)
+                if sdk_recharge.breathing_samples
+                else None
+            ),
+            # SDK doesn't provide per-metric status fields or sleep metrics
             # Database columns hrv_status, breathing_rate_status, heart_rate_status,
             # sleep_score, sleep_charge, sleep_charge_status remain null
         }

--- a/src/polar_flow_server/transformers/sleep.py
+++ b/src/polar_flow_server/transformers/sleep.py
@@ -5,6 +5,7 @@ Converts polar-flow SDK SleepData model to database-ready dictionary.
 
 from __future__ import annotations
 
+import json
 from datetime import date as date_type
 from typing import TYPE_CHECKING, Any
 
@@ -13,7 +14,12 @@ if TYPE_CHECKING:
 
 
 class SleepTransformer:
-    """Transform SDK SleepData -> Database Sleep dict."""
+    """Transform SDK SleepData -> Database Sleep dict.
+
+    Polar uses in-band sentinels for "no data" (continuity 0, sleep_charge -1,
+    heart rate 0); those are stored as NULL so aggregates and baselines never
+    ingest them as real values.
+    """
 
     @staticmethod
     def transform(sdk_sleep: SleepData, user_id: str) -> dict[str, Any]:
@@ -21,6 +27,10 @@ class SleepTransformer:
         sleep_date = sdk_sleep.date
         if isinstance(sleep_date, str):
             sleep_date = date_type.fromisoformat(sleep_date)
+
+        # Overnight HR aggregates from the ~5-minute sample series.
+        # Zero-bpm samples mean "no signal", never a real heart rate.
+        hr_values = [v for v in (sdk_sleep.heart_rate_samples or {}).values() if v > 0]
 
         return {
             "date": sleep_date,
@@ -39,4 +49,34 @@ class SleepTransformer:
             "interruptions_seconds": sdk_sleep.total_interruption_duration,
             "sleep_score": sdk_sleep.sleep_score,
             "sleep_rating": sdk_sleep.sleep_rating,
+            # Device & sleep structure
+            "device_id": sdk_sleep.device_id or None,
+            # Polar sends 0 / class 0 when continuity wasn't measured
+            "continuity": sdk_sleep.continuity if sdk_sleep.continuity > 0 else None,
+            "continuity_class": (
+                sdk_sleep.continuity_class if sdk_sleep.continuity_class > 0 else None
+            ),
+            "sleep_cycles": sdk_sleep.sleep_cycles,
+            "unrecognized_sleep_seconds": sdk_sleep.unrecognized_sleep_stage,
+            "short_interruption_seconds": sdk_sleep.short_interruption_duration,
+            "long_interruption_seconds": sdk_sleep.long_interruption_duration,
+            # Polar sends -1 when sleep charge is unavailable
+            "sleep_charge": (
+                sdk_sleep.sleep_charge
+                if sdk_sleep.sleep_charge is not None and sdk_sleep.sleep_charge > 0
+                else None
+            ),
+            "sleep_goal_seconds": sdk_sleep.sleep_goal,
+            "group_duration_score": sdk_sleep.group_duration_score,
+            "group_solidity_score": sdk_sleep.group_solidity_score,
+            "group_regeneration_score": sdk_sleep.group_regeneration_score,
+            # Overnight series
+            "hypnogram_json": (json.dumps(sdk_sleep.hypnogram) if sdk_sleep.hypnogram else None),
+            "heart_rate_samples_json": (
+                json.dumps(sdk_sleep.heart_rate_samples) if sdk_sleep.heart_rate_samples else None
+            ),
+            # In-sleep HR aggregates derived from the sample series
+            "heart_rate_avg": round(sum(hr_values) / len(hr_values), 1) if hr_values else None,
+            "heart_rate_min": min(hr_values) if hr_values else None,
+            "heart_rate_max": max(hr_values) if hr_values else None,
         }

--- a/tests/test_sleep_recharge_transformers.py
+++ b/tests/test_sleep_recharge_transformers.py
@@ -1,0 +1,160 @@
+"""Tests for the rich sleep/recharge capture (issue #77).
+
+Verifies the transformers keep every field the API returns, apply Polar's
+in-band no-data sentinels (continuity 0, sleep_charge -1, zero heart rates)
+as NULL, and derive in-sleep HR aggregates from the sample series.
+"""
+
+from __future__ import annotations
+
+import json
+
+from polar_flow.models.recharge import NightlyRecharge
+from polar_flow.models.sleep import SleepData
+
+from polar_flow_server.transformers.recharge import RechargeTransformer
+from polar_flow_server.transformers.sleep import SleepTransformer
+
+USER_ID = "12345"
+
+
+def _sleep(**overrides: object) -> SleepData:
+    base: dict[str, object] = {
+        "polar_user": "https://www.polaraccesslink.com/v3/users/1",
+        "date": "2026-06-01",
+        "sleep_start_time": "2026-05-31T23:10:00+01:00",
+        "sleep_end_time": "2026-06-01T07:05:00+01:00",
+        "device_id": "ABC123",
+        "continuity": 3.4,
+        "continuity_class": 3,
+        "light_sleep": 14000,
+        "deep_sleep": 6000,
+        "rem_sleep": 5000,
+        "unrecognized_sleep_stage": 300,
+        "sleep_score": 82,
+        "total_interruption_duration": 1200,
+        "sleep_charge": 78,
+        "sleep_goal": 28800,
+        "sleep_rating": 4,
+        "short_interruption_duration": 900,
+        "long_interruption_duration": 300,
+        "sleep_cycles": 5,
+        "group_duration_score": 88.0,
+        "group_solidity_score": 74.5,
+        "group_regeneration_score": 81.0,
+        "hypnogram": {"00:39": 1, "01:19": 3, "02:05": 4, "03:10": 0},
+        "heart_rate_samples": {"23:15": 62, "00:15": 58, "01:15": 0, "02:15": 54},
+    }
+    base.update(overrides)
+    return SleepData.model_validate(base)
+
+
+def _recharge(**overrides: object) -> NightlyRecharge:
+    base: dict[str, object] = {
+        "polar-user": "https://www.polaraccesslink.com/v3/users/1",
+        "date": "2026-06-01",
+        "heart-rate-avg": 55,
+        "beat-to-beat-avg": 1090,
+        "heart-rate-variability-avg": 45,
+        "breathing-rate-avg": 13.2,
+        "nightly-recharge-status": 4,
+        "ans-charge": 2.5,
+        "ans-charge-status": 4,
+        "hrv-samples": {"23:20": 44, "23:25": 47},
+        "breathing-samples": {"23:20": 12.8, "23:25": 13.1},
+    }
+    base.update(overrides)
+    return NightlyRecharge.model_validate(base)
+
+
+class TestSleepTransformer:
+    def test_captures_structure_fields(self) -> None:
+        result = SleepTransformer.transform(_sleep(), USER_ID)
+
+        assert result["device_id"] == "ABC123"
+        assert result["continuity"] == 3.4
+        assert result["continuity_class"] == 3
+        assert result["sleep_cycles"] == 5
+        assert result["unrecognized_sleep_seconds"] == 300
+        assert result["short_interruption_seconds"] == 900
+        assert result["long_interruption_seconds"] == 300
+        assert result["sleep_charge"] == 78
+        assert result["sleep_goal_seconds"] == 28800
+        assert result["group_duration_score"] == 88.0
+        assert result["group_solidity_score"] == 74.5
+        assert result["group_regeneration_score"] == 81.0
+
+    def test_series_stored_as_json(self) -> None:
+        result = SleepTransformer.transform(_sleep(), USER_ID)
+
+        hypnogram = json.loads(result["hypnogram_json"])
+        assert hypnogram["01:19"] == 3
+        hr = json.loads(result["heart_rate_samples_json"])
+        assert hr["23:15"] == 62
+
+    def test_hr_aggregates_derived_excluding_zero_signal(self) -> None:
+        result = SleepTransformer.transform(_sleep(), USER_ID)
+
+        # 62, 58, 54 count; the 0 sample is no-signal, not a heart rate
+        assert result["heart_rate_min"] == 54
+        assert result["heart_rate_max"] == 62
+        assert result["heart_rate_avg"] == 58.0
+
+    def test_no_samples_leaves_aggregates_null(self) -> None:
+        result = SleepTransformer.transform(
+            _sleep(hypnogram=None, heart_rate_samples=None), USER_ID
+        )
+
+        assert result["hypnogram_json"] is None
+        assert result["heart_rate_samples_json"] is None
+        assert result["heart_rate_avg"] is None
+        assert result["heart_rate_min"] is None
+        assert result["heart_rate_max"] is None
+
+    def test_no_data_sentinels_become_null(self) -> None:
+        result = SleepTransformer.transform(
+            _sleep(continuity=0.0, continuity_class=0, sleep_charge=-1), USER_ID
+        )
+
+        assert result["continuity"] is None
+        assert result["continuity_class"] is None
+        assert result["sleep_charge"] is None
+
+    def test_existing_fields_unchanged(self) -> None:
+        result = SleepTransformer.transform(_sleep(), USER_ID)
+
+        assert str(result["date"]) == "2026-06-01"
+        assert result["total_sleep_seconds"] == 25000
+        assert result["sleep_score"] == 82
+        assert result["interruptions_seconds"] == 1200
+
+
+class TestRechargeTransformer:
+    def test_captures_new_fields(self) -> None:
+        result = RechargeTransformer.transform(_recharge(), USER_ID)
+
+        assert result["nightly_recharge_status"] == 4
+        assert result["beat_to_beat_avg"] == 1090
+        assert json.loads(result["hrv_samples_json"])["23:25"] == 47
+        assert json.loads(result["breathing_samples_json"])["23:20"] == 12.8
+
+    def test_zero_beat_to_beat_is_no_signal(self) -> None:
+        result = RechargeTransformer.transform(_recharge(**{"beat-to-beat-avg": 0}), USER_ID)
+
+        assert result["beat_to_beat_avg"] is None
+
+    def test_missing_series_stay_null(self) -> None:
+        result = RechargeTransformer.transform(
+            _recharge(**{"hrv-samples": None, "breathing-samples": None}), USER_ID
+        )
+
+        assert result["hrv_samples_json"] is None
+        assert result["breathing_samples_json"] is None
+
+    def test_existing_fields_unchanged(self) -> None:
+        result = RechargeTransformer.transform(_recharge(), USER_ID)
+
+        assert str(result["date"]) == "2026-06-01"
+        assert result["hrv_avg"] == 45
+        assert result["ans_charge"] == 2.5
+        assert result["heart_rate_avg"] == 55


### PR DESCRIPTION
Closes #77.

The transformers were fetching rich data from Polar and throwing most of it away before storage. Since AccessLink only serves ~28 days back, every synced day without this capture loses the detail forever — landing it now means the moment the device next uploads, the richest version of the data is kept from day one.

## Sleep
- **Overnight series captured as JSON**: `hypnogram_json` (time → stage: 0=awake, 1=light, 3=deep, 4=REM) and `heart_rate_samples_json` (time → bpm, ~5-min intervals)
- **Structure scalars**: `device_id`, `continuity` + `continuity_class`, `sleep_cycles`, `unrecognized_sleep_seconds`, `short/long_interruption_seconds`, `sleep_charge`, `sleep_goal_seconds`, `group_duration/solidity/regeneration_score`
- **Dead columns finally populated**: `heart_rate_avg/min/max` are now derived from the sample series (zero-bpm samples are no-signal and excluded — same rule as the continuous-HR fix in #121)

## Nightly recharge
- `nightly_recharge_status` (the 1–6 overall recovery status — was never stored!), `beat_to_beat_avg` (0 → NULL), and the 5-minute `hrv_samples_json` / `breathing_samples_json` series

## Sentinel hygiene
Polar's in-band no-data markers (`continuity: 0`, `sleep_charge: -1`, zero heart rates) are stored as NULL so baselines and aggregates never ingest them as real values.

## Surfaced
- REST: sleep by-date detail returns the new scalars **and the parsed hypnogram/HR series**; recharge list gains the two new scalars
- MCP: `get_sleep` / `get_recovery` gain the scalars only (raw series stay out of agent context by default)

Migration `i0j1k2l3m4n5` adds the columns. 314 tests passing (10 new transformer tests covering capture, sentinels, and HR-aggregate derivation), mypy clean.