### PR TITLE
Sync physical info: VO2 max, thresholds, resting HR (#75)

### DIFF
--- a/alembic/versions/j1k2l3m4n5o6_add_physical_info.py
+++ b/alembic/versions/j1k2l3m4n5o6_add_physical_info.py
@@ -1,0 +1,60 @@
+"""Add physical_info snapshots table (issue #75).
+
+VO2 max, HR thresholds, weight, and profile settings from the
+non-transactional GET /v3/users/physical-info endpoint (AccessLink
+13.01.2026). Keyed by (user_id, recorded_at) so profile changes build
+a history while repeated syncs stay idempotent.
+
+Revision ID: j1k2l3m4n5o6
+Revises: i0j1k2l3m4n5
+Create Date: 2026-08-05 13:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "j1k2l3m4n5o6"
+down_revision: str | None = "i0j1k2l3m4n5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create physical_info table."""
+    op.create_table(
+        "physical_info",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("user_id", sa.String(255), nullable=False, index=True),
+        sa.Column("recorded_at", sa.DateTime(timezone=True), nullable=False, index=True),
+        sa.Column("weight_kg", sa.Float(), nullable=True),
+        sa.Column("height_cm", sa.Float(), nullable=True),
+        sa.Column("birthday", sa.Date(), nullable=True),
+        sa.Column("gender", sa.String(20), nullable=True),
+        sa.Column("maximum_heart_rate", sa.Integer(), nullable=True),
+        sa.Column("resting_heart_rate", sa.Integer(), nullable=True),
+        sa.Column("aerobic_threshold", sa.Integer(), nullable=True),
+        sa.Column("anaerobic_threshold", sa.Integer(), nullable=True),
+        sa.Column("vo2_max", sa.Integer(), nullable=True),
+        sa.Column("weight_source", sa.String(30), nullable=True),
+        sa.Column("training_background", sa.String(30), nullable=True),
+        sa.Column("typical_day", sa.String(30), nullable=True),
+        sa.Column("sleep_goal_seconds", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.UniqueConstraint("user_id", "recorded_at", name="uq_physical_info_user_recorded"),
+        comment="Physical info snapshots (VO2 max, HR thresholds, weight)",
+    )
+
+
+def downgrade() -> None:
+    """Drop physical_info table."""
+    op.drop_table("physical_info")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "asyncpg>=0.31.0",  # PostgreSQL async driver
     "psycopg[binary]>=3.2.3",  # PostgreSQL sync driver (for Alembic migrations)
     # Polar Flow SDK
-    "polar-flow-api>=1.4.0",
+    "polar-flow-api>=1.5.0",
     # Data processing
     "polars>=1.17.1",
     "pyarrow>=23.0.1",

--- a/src/polar_flow_server/api/data.py
+++ b/src/polar_flow_server/api/data.py
@@ -18,6 +18,7 @@ from polar_flow_server.models.cardio_load import CardioLoad
 from polar_flow_server.models.continuous_hr import ContinuousHeartRate
 from polar_flow_server.models.ecg import ECG
 from polar_flow_server.models.exercise import Exercise
+from polar_flow_server.models.physical_info import PhysicalInfo
 from polar_flow_server.models.recharge import NightlyRecharge
 from polar_flow_server.models.sleepwise_alertness import SleepWiseAlertness
 from polar_flow_server.models.sleepwise_bedtime import SleepWiseBedtime
@@ -139,6 +140,54 @@ async def get_recharge_list(
         }
         for r in records
     ]
+
+
+# ==============================================================================
+# Physical Info Endpoints
+# ==============================================================================
+
+
+@get("/users/{user_id:str}/physical-info", status_code=HTTP_200_OK)
+async def get_physical_info(
+    user_id: str,
+    session: AsyncSession,
+) -> dict[str, Any] | None:
+    """Get the user's current physical information (VO2 max, HR thresholds, weight).
+
+    Returns the most recent snapshot, plus a short history of older
+    snapshots so weight / VO2 max changes over time are visible.
+    """
+    stmt = (
+        select(PhysicalInfo)
+        .where(PhysicalInfo.user_id == user_id)
+        .order_by(PhysicalInfo.recorded_at.desc())
+    )
+    result = await session.execute(stmt)
+    records = result.scalars().all()
+
+    if not records:
+        return None
+
+    def _serialize(r: PhysicalInfo) -> dict[str, Any]:
+        return {
+            "recorded_at": r.recorded_at.isoformat(),
+            "weight_kg": r.weight_kg,
+            "height_cm": r.height_cm,
+            "maximum_heart_rate": r.maximum_heart_rate,
+            "resting_heart_rate": r.resting_heart_rate,
+            "aerobic_threshold": r.aerobic_threshold,
+            "anaerobic_threshold": r.anaerobic_threshold,
+            "vo2_max": r.vo2_max,
+            "weight_source": r.weight_source,
+            "training_background": r.training_background,
+            "typical_day": r.typical_day,
+            "sleep_goal_hours": (r.sleep_goal_seconds / 3600 if r.sleep_goal_seconds else None),
+        }
+
+    return {
+        **_serialize(records[0]),
+        "history": [_serialize(r) for r in records[1:11]],
+    }
 
 
 # ==============================================================================
@@ -602,6 +651,8 @@ data_router = Router(
         get_activity_by_date,
         # Recharge
         get_recharge_list,
+        # Physical Info
+        get_physical_info,
         # Cardio Load
         get_cardio_load_list,
         # Heart Rate

--- a/src/polar_flow_server/mcp_server/tools.py
+++ b/src/polar_flow_server/mcp_server/tools.py
@@ -23,6 +23,7 @@ from polar_flow_server.models.cardio_load import CardioLoad
 from polar_flow_server.models.continuous_hr import ContinuousHeartRate
 from polar_flow_server.models.ecg import ECG
 from polar_flow_server.models.exercise import Exercise
+from polar_flow_server.models.physical_info import PhysicalInfo
 from polar_flow_server.models.recharge import NightlyRecharge
 from polar_flow_server.models.sleep import Sleep
 from polar_flow_server.models.sleepwise_alertness import SleepWiseAlertness
@@ -381,7 +382,7 @@ async def get_biosensing(
 
 
 async def get_baselines(user_id: UserIdParam = None) -> dict[str, Any]:
-    """Get the user's personal baselines for key health metrics.
+    """Get the user's personal baselines and physical reference values.
 
     Baselines exist for hrv_rmssd, sleep_score, resting_hr, training_load,
     and training_load_ratio. Each has rolling averages (7d/30d/90d), median
@@ -390,6 +391,11 @@ async def get_baselines(user_id: UserIdParam = None) -> dict[str, Any]:
     says how much history backs it (ready/partial/insufficient). Use these
     to judge whether a current reading from other tools is meaningfully
     high or low rather than comparing to population norms.
+
+    `physical_info` (when synced) carries the user's profile reference
+    values: VO2 max (ml/kg/min), max/resting heart rate, aerobic and
+    anaerobic thresholds (bpm - useful for interpreting exercise heart
+    rates and zones), weight, height, and sleep goal.
     """
     uid = await resolve_scoped_user_id(user_id)
 
@@ -398,9 +404,35 @@ async def get_baselines(user_id: UserIdParam = None) -> dict[str, Any]:
 
     async with async_session_maker() as session:
         baselines = await BaselineService(session).get_user_baselines(uid)
+        info_result = await session.execute(
+            select(PhysicalInfo)
+            .where(PhysicalInfo.user_id == uid)
+            .order_by(PhysicalInfo.recorded_at.desc())
+            .limit(1)
+        )
+        info = info_result.scalar_one_or_none()
+
+    physical_info = (
+        {
+            "recorded_at": info.recorded_at.isoformat(),
+            "vo2_max": info.vo2_max,
+            "maximum_heart_rate_bpm": info.maximum_heart_rate,
+            "resting_heart_rate_bpm": info.resting_heart_rate,
+            "aerobic_threshold_bpm": info.aerobic_threshold,
+            "anaerobic_threshold_bpm": info.anaerobic_threshold,
+            "weight_kg": info.weight_kg,
+            "height_cm": info.height_cm,
+            "sleep_goal_hours": (
+                round(info.sleep_goal_seconds / 3600, 2) if info.sleep_goal_seconds else None
+            ),
+        }
+        if info
+        else None
+    )
 
     return {
         "count": len(baselines),
+        "physical_info": physical_info,
         "baselines": [
             {
                 "metric_name": b.metric_name,

--- a/src/polar_flow_server/models/__init__.py
+++ b/src/polar_flow_server/models/__init__.py
@@ -17,6 +17,7 @@ from polar_flow_server.models.pattern import (
     PatternType,
     Significance,
 )
+from polar_flow_server.models.physical_info import PhysicalInfo
 from polar_flow_server.models.recharge import NightlyRecharge
 from polar_flow_server.models.settings import AppSettings
 from polar_flow_server.models.sleep import Sleep
@@ -55,6 +56,7 @@ __all__ = [
     "PatternAnalysis",
     "PatternName",
     "PatternType",
+    "PhysicalInfo",
     "Significance",
     "SkinTemperature",
     "Sleep",

--- a/src/polar_flow_server/models/physical_info.py
+++ b/src/polar_flow_server/models/physical_info.py
@@ -1,0 +1,56 @@
+"""Physical information model."""
+
+from datetime import date, datetime
+
+from sqlalchemy import Date, DateTime, Float, Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from polar_flow_server.models.base import Base, TimestampMixin, UserScopedMixin, generate_uuid
+
+
+class PhysicalInfo(Base, UserScopedMixin, TimestampMixin):
+    """Physical information snapshots from Polar (VO2 max, thresholds, weight).
+
+    One row per Polar-side modification: syncs upsert on (user_id, recorded_at)
+    where recorded_at is Polar's modified timestamp, so repeated syncs are
+    idempotent while profile changes over time build a history (weight and
+    VO2 max trends).
+    """
+
+    __tablename__ = "physical_info"
+    __table_args__ = (
+        UniqueConstraint("user_id", "recorded_at", name="uq_physical_info_user_recorded"),
+        {"comment": "Physical info snapshots (VO2 max, HR thresholds, weight)"},
+    )
+
+    id: Mapped[str] = mapped_column(
+        String(36),
+        primary_key=True,
+        default=generate_uuid,
+    )
+
+    # Polar's modified (falling back to created) timestamp for this snapshot
+    recorded_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True, comment="Polar modified timestamp"
+    )
+
+    weight_kg: Mapped[float | None] = mapped_column(Float)
+    height_cm: Mapped[float | None] = mapped_column(Float)
+    birthday: Mapped[date | None] = mapped_column(Date)
+    gender: Mapped[str | None] = mapped_column(String(20))
+    maximum_heart_rate: Mapped[int | None] = mapped_column(Integer, comment="bpm")
+    resting_heart_rate: Mapped[int | None] = mapped_column(Integer, comment="bpm")
+    aerobic_threshold: Mapped[int | None] = mapped_column(Integer, comment="bpm")
+    anaerobic_threshold: Mapped[int | None] = mapped_column(Integer, comment="bpm")
+    vo2_max: Mapped[int | None] = mapped_column(Integer, comment="ml/kg/min")
+    weight_source: Mapped[str | None] = mapped_column(String(30))
+    training_background: Mapped[str | None] = mapped_column(String(30))
+    typical_day: Mapped[str | None] = mapped_column(String(30))
+    sleep_goal_seconds: Mapped[int | None] = mapped_column(Integer)
+
+    def __repr__(self) -> str:
+        """String representation."""
+        return (
+            f"<PhysicalInfo(user_id={self.user_id}, recorded_at={self.recorded_at}, "
+            f"vo2_max={self.vo2_max})>"
+        )

--- a/src/polar_flow_server/services/sync.py
+++ b/src/polar_flow_server/services/sync.py
@@ -19,6 +19,7 @@ from polar_flow_server.models.cardio_load import CardioLoad
 from polar_flow_server.models.continuous_hr import ContinuousHeartRate
 from polar_flow_server.models.ecg import ECG
 from polar_flow_server.models.exercise import Exercise
+from polar_flow_server.models.physical_info import PhysicalInfo
 from polar_flow_server.models.recharge import NightlyRecharge
 from polar_flow_server.models.sleep import Sleep
 from polar_flow_server.models.sleepwise_alertness import SleepWiseAlertness
@@ -36,6 +37,7 @@ from polar_flow_server.transformers import (
     ContinuousHRTransformer,
     ECGTransformer,
     ExerciseTransformer,
+    PhysicalInfoTransformer,
     RechargeTransformer,
     SkinTemperatureTransformer,
     SleepTransformer,
@@ -245,6 +247,7 @@ class SyncService:
                 "ecg": 0,
                 "body_temperature": 0,
                 "skin_temperature": 0,
+                "physical_info": 0,
             },
             errors={},
         )
@@ -400,6 +403,19 @@ class SyncService:
                     result.errors["skin_temperature"] = error_msg
                     self.logger.warning(
                         "Skin temperature sync failed", user_id=user_id, error=error_msg
+                    )
+
+            # Sync physical info (requires SDK >= 1.5.0 non-transactional endpoint)
+            if hasattr(client.physical_info, "get"):
+                try:
+                    result.records["physical_info"] = await self._call_with_retry(
+                        result, "physical_info", self._sync_physical_info, client, user_id
+                    )
+                except Exception as e:
+                    error_msg = _format_polar_error(e, "physical_info")
+                    result.errors["physical_info"] = error_msg
+                    self.logger.warning(
+                        "Physical info sync failed", user_id=user_id, error=error_msg
                     )
 
         # Commit all changes to database
@@ -598,6 +614,43 @@ class SyncService:
             count += 1
 
         return count
+
+    async def _sync_physical_info(
+        self,
+        client: PolarFlow,
+        user_id: str,
+    ) -> int:
+        """Sync physical information (VO2 max, HR thresholds, weight).
+
+        Uses the non-transactional GET /v3/users/physical-info endpoint
+        (SDK >= 1.5.0). Snapshots are keyed by Polar's modified timestamp,
+        so unchanged profiles upsert the same row.
+
+        Args:
+            client: Polar Flow client
+            user_id: User identifier
+
+        Returns:
+            Number of physical info records synced (0 or 1)
+        """
+        self.logger.debug("Syncing physical info", user_id=user_id)
+
+        try:
+            info = await client.physical_info.get()
+        except NotFoundError:
+            # User has never filled in physical info - absence is not an error
+            return 0
+
+        info_dict = PhysicalInfoTransformer.transform(info, user_id)
+
+        stmt = insert(PhysicalInfo).values(user_id=user_id, **info_dict)
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["user_id", "recorded_at"],
+            set_=info_dict,
+        )
+
+        await self.session.execute(stmt)
+        return 1
 
     async def _sync_cardio_load(
         self,

--- a/src/polar_flow_server/transformers/__init__.py
+++ b/src/polar_flow_server/transformers/__init__.py
@@ -6,6 +6,7 @@ from polar_flow_server.transformers.cardio_load import CardioLoadTransformer
 from polar_flow_server.transformers.continuous_hr import ContinuousHRTransformer
 from polar_flow_server.transformers.ecg import ECGTransformer
 from polar_flow_server.transformers.exercise import ExerciseTransformer
+from polar_flow_server.transformers.physical_info import PhysicalInfoTransformer
 from polar_flow_server.transformers.recharge import RechargeTransformer
 from polar_flow_server.transformers.sleep import SleepTransformer
 from polar_flow_server.transformers.sleepwise_alertness import SleepWiseAlertnessTransformer
@@ -24,6 +25,7 @@ __all__ = [
     "ContinuousHRTransformer",
     "ECGTransformer",
     "ExerciseTransformer",
+    "PhysicalInfoTransformer",
     "RechargeTransformer",
     "SkinTemperatureTransformer",
     "SleepTransformer",

--- a/src/polar_flow_server/transformers/physical_info.py
+++ b/src/polar_flow_server/transformers/physical_info.py
@@ -1,0 +1,59 @@
+"""Physical information transformer.
+
+Converts polar-flow SDK UserPhysicalInfo model to database-ready dictionary.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from polar_flow.models.physical_info import UserPhysicalInfo
+
+_DURATION_PATTERN = re.compile(r"PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?")
+
+
+def _duration_seconds(value: str | None) -> int | None:
+    """Parse an ISO 8601 duration like PT8H to seconds."""
+    if not value:
+        return None
+    match = _DURATION_PATTERN.match(value)
+    if not match or not any(match.groups()):
+        return None
+    hours = int(match.group(1) or 0)
+    minutes = int(match.group(2) or 0)
+    seconds = float(match.group(3) or 0)
+    return int(hours * 3600 + minutes * 60 + seconds)
+
+
+class PhysicalInfoTransformer:
+    """Transform SDK UserPhysicalInfo -> Database PhysicalInfo dict.
+
+    recorded_at is Polar's modified timestamp (falling back to created, then
+    the sync moment) so the (user_id, recorded_at) upsert stays idempotent
+    across repeated syncs while real profile changes create new history rows.
+    """
+
+    @staticmethod
+    def transform(sdk_info: UserPhysicalInfo, user_id: str) -> dict[str, Any]:
+        """Convert SDK physical info model to database-ready dict."""
+        recorded_at = sdk_info.modified or sdk_info.created or datetime.now(tz=UTC)
+
+        return {
+            "recorded_at": recorded_at,
+            "weight_kg": sdk_info.weight,
+            "height_cm": sdk_info.height,
+            "birthday": sdk_info.birthday,
+            "gender": sdk_info.gender,
+            "maximum_heart_rate": sdk_info.maximum_heart_rate,
+            "resting_heart_rate": sdk_info.resting_heart_rate,
+            "aerobic_threshold": sdk_info.aerobic_threshold,
+            "anaerobic_threshold": sdk_info.anaerobic_threshold,
+            "vo2_max": sdk_info.vo2_max,
+            "weight_source": sdk_info.weight_source,
+            "training_background": sdk_info.training_background,
+            "typical_day": sdk_info.typical_day,
+            "sleep_goal_seconds": _duration_seconds(sdk_info.sleep_goal),
+        }

--- a/tests/test_biosensing_error_propagation.py
+++ b/tests/test_biosensing_error_propagation.py
@@ -38,6 +38,9 @@ def _mock_client() -> AsyncMock:
     client.biosensing.get_ecg = AsyncMock(return_value=[])
     client.biosensing.get_body_temperature = AsyncMock(return_value=[])
     client.biosensing.get_skin_temperature = AsyncMock(return_value=[])
+    client.physical_info.get = AsyncMock(
+        side_effect=NotFoundError("API error 404: Not Found", status_code=404)
+    )
     return client
 
 

--- a/tests/test_physical_info.py
+++ b/tests/test_physical_info.py
@@ -1,0 +1,180 @@
+"""Tests for physical info capture (issue #75).
+
+The transformer is exercised with a duck-typed stand-in for the SDK's
+UserPhysicalInfo model (added in polar-flow-api 1.5.0) so this suite
+passes regardless of which SDK version is installed — the sync step is
+hasattr-gated the same way.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from types import SimpleNamespace
+
+import pytest
+
+from polar_flow_server.transformers.physical_info import PhysicalInfoTransformer, _duration_seconds
+
+USER_ID = "polar-1"
+
+
+def _sdk_info(**overrides: object) -> SimpleNamespace:
+    base = {
+        "weight": 70.5,
+        "height": 175.0,
+        "created": dt.datetime(2026, 6, 1, 12, 0, tzinfo=dt.UTC),
+        "modified": dt.datetime(2026, 6, 10, 12, 0, tzinfo=dt.UTC),
+        "birthday": dt.date(1990, 1, 1),
+        "gender": "MALE",
+        "maximum_heart_rate": 190,
+        "resting_heart_rate": 60,
+        "aerobic_threshold": 140,
+        "anaerobic_threshold": 170,
+        "vo2_max": 50,
+        "weight_source": "SOURCE_USER",
+        "training_background": "REGULAR",
+        "typical_day": "MOSTLY_MOVING",
+        "sleep_goal": "PT8H",
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class TestPhysicalInfoTransformer:
+    def test_transforms_all_fields(self) -> None:
+        result = PhysicalInfoTransformer.transform(_sdk_info(), USER_ID)
+
+        assert result["recorded_at"] == dt.datetime(2026, 6, 10, 12, 0, tzinfo=dt.UTC)
+        assert result["weight_kg"] == 70.5
+        assert result["height_cm"] == 175.0
+        assert result["birthday"] == dt.date(1990, 1, 1)
+        assert result["gender"] == "MALE"
+        assert result["maximum_heart_rate"] == 190
+        assert result["resting_heart_rate"] == 60
+        assert result["aerobic_threshold"] == 140
+        assert result["anaerobic_threshold"] == 170
+        assert result["vo2_max"] == 50
+        assert result["training_background"] == "REGULAR"
+        assert result["sleep_goal_seconds"] == 28800
+
+    def test_recorded_at_falls_back_to_created(self) -> None:
+        result = PhysicalInfoTransformer.transform(_sdk_info(modified=None), USER_ID)
+
+        assert result["recorded_at"] == dt.datetime(2026, 6, 1, 12, 0, tzinfo=dt.UTC)
+
+    def test_sleep_goal_parsing(self) -> None:
+        assert _duration_seconds("PT8H") == 28800
+        assert _duration_seconds("PT7H30M") == 27000
+        assert _duration_seconds("PT45M") == 2700
+        assert _duration_seconds(None) is None
+        assert _duration_seconds("") is None
+        assert _duration_seconds("garbage") is None
+
+
+async def _seed_user_with_key() -> str:
+    from polar_flow_server.core.api_keys import create_api_key_for_user
+    from polar_flow_server.core.database import async_session_maker
+    from polar_flow_server.models.user import User
+
+    async with async_session_maker() as session:
+        session.add(
+            User(
+                id="user-1",
+                polar_user_id=USER_ID,
+                access_token_encrypted="not-a-real-token",
+                is_active=True,
+            )
+        )
+        await session.flush()
+        _, raw_key = await create_api_key_for_user(
+            user_id=USER_ID, name="test key", session=session
+        )
+        await session.commit()
+    return raw_key
+
+
+async def _seed_physical_info(snapshots: int = 1) -> None:
+    from polar_flow_server.core.database import async_session_maker
+    from polar_flow_server.models.physical_info import PhysicalInfo
+
+    async with async_session_maker() as session:
+        for i in range(snapshots):
+            session.add(
+                PhysicalInfo(
+                    user_id=USER_ID,
+                    recorded_at=dt.datetime(2026, 6, 1 + i, 12, 0, tzinfo=dt.UTC),
+                    weight_kg=70.0 + i,
+                    height_cm=175.0,
+                    maximum_heart_rate=190,
+                    resting_heart_rate=60,
+                    aerobic_threshold=140,
+                    anaerobic_threshold=170,
+                    vo2_max=50 + i,
+                    sleep_goal_seconds=28800,
+                )
+            )
+        await session.commit()
+
+
+class TestPhysicalInfoEndpoint:
+    @pytest.mark.asyncio
+    async def test_latest_snapshot_with_history(self, app_client) -> None:
+        key = await _seed_user_with_key()
+        await _seed_physical_info(snapshots=3)
+
+        response = await app_client.get(
+            f"/api/v1/users/{USER_ID}/physical-info", headers={"X-API-Key": key}
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        # Most recent snapshot first (highest vo2), older ones in history
+        assert payload["vo2_max"] == 52
+        assert payload["weight_kg"] == 72.0
+        assert payload["sleep_goal_hours"] == 8.0
+        assert len(payload["history"]) == 2
+        assert payload["history"][0]["vo2_max"] == 51
+
+    @pytest.mark.asyncio
+    async def test_no_data_returns_null(self, app_client) -> None:
+        key = await _seed_user_with_key()
+
+        response = await app_client.get(
+            f"/api/v1/users/{USER_ID}/physical-info", headers={"X-API-Key": key}
+        )
+
+        assert response.status_code == 200
+        assert response.json() is None
+
+
+class TestMCPBaselinesPhysicalInfo:
+    @pytest.mark.asyncio
+    async def test_baselines_carries_physical_info(self, app_client) -> None:
+        from tests.test_mcp_server import _mcp_client, _seed_user, _user_key
+
+        user_id = await _seed_user(USER_ID)
+        await _seed_physical_info()
+        raw_key = await _user_key(user_id)
+
+        async with _mcp_client(app_client.app, raw_key) as client:
+            result = await client.call_tool("get_baselines", {})
+
+        assert not result.is_error
+        info = result.structured_content["physical_info"]
+        assert info["vo2_max"] == 50
+        assert info["resting_heart_rate_bpm"] == 60
+        assert info["anaerobic_threshold_bpm"] == 170
+        assert info["sleep_goal_hours"] == 8.0
+
+    @pytest.mark.asyncio
+    async def test_baselines_physical_info_null_when_unsynced(self, app_client) -> None:
+        from tests.test_mcp_server import _mcp_client, _seed_user, _user_key
+
+        user_id = await _seed_user(USER_ID)
+        raw_key = await _user_key(user_id)
+
+        async with _mcp_client(app_client.app, raw_key) as client:
+            result = await client.call_tool("get_baselines", {})
+
+        assert not result.is_error
+        assert result.structured_content["physical_info"] is None

--- a/tests/test_sync_error_handling.py
+++ b/tests/test_sync_error_handling.py
@@ -9,7 +9,7 @@ Tests that:
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from polar_flow.exceptions import PolarFlowError
+from polar_flow.exceptions import NotFoundError, PolarFlowError
 
 from polar_flow_server.services.sync import SyncResult, SyncService
 
@@ -33,6 +33,9 @@ async def test_sync_sleep_403_captured_as_error(async_session):
     mock_client.recharge.list = AsyncMock(return_value=[])
     mock_client.activity.list = AsyncMock(return_value=[])
     mock_client.exercises.list = AsyncMock(return_value=[])
+    mock_client.physical_info.get = AsyncMock(
+        side_effect=NotFoundError("API error 404: Not Found", status_code=404)
+    )
 
     # Mock hasattr checks for optional features
     original_hasattr = hasattr
@@ -89,6 +92,9 @@ async def test_sync_continues_after_endpoint_failure(async_session):
     mock_client.recharge.list = AsyncMock(return_value=[])
     mock_client.activity.list = AsyncMock(return_value=[])
     mock_client.exercises.list = AsyncMock(return_value=[])
+    mock_client.physical_info.get = AsyncMock(
+        side_effect=NotFoundError("API error 404: Not Found", status_code=404)
+    )
 
     # Mock hasattr checks for optional features
     original_hasattr = hasattr
@@ -140,6 +146,9 @@ async def test_sync_success_returns_counts(async_session):
     mock_client.recharge.list = AsyncMock(return_value=[])
     mock_client.activity.list = AsyncMock(return_value=[])
     mock_client.exercises.list = AsyncMock(return_value=[])
+    mock_client.physical_info.get = AsyncMock(
+        side_effect=NotFoundError("API error 404: Not Found", status_code=404)
+    )
 
     # Mock hasattr checks - these need to return False for optional features
     original_hasattr = hasattr

--- a/uv.lock
+++ b/uv.lock
@@ -1513,7 +1513,7 @@ wheels = [
 
 [[package]]
 name = "polar-flow-api"
-version = "1.4.0"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1521,9 +1521,9 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/a3/82389d0847b933d9f70da69741409d954ecb937165f969fa9e8b2bfb8aab/polar_flow_api-1.4.0.tar.gz", hash = "sha256:a955b755bbb096678953769bdf47d9fffe4409dbb2b94222c6fc070d83d21cd3", size = 134138, upload-time = "2026-01-11T12:02:49.572Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/9e/d87898b571e8cfe4ff9c9a646de976a704abb66dd2f229be1f46e07a21f7/polar_flow_api-1.5.0.tar.gz", hash = "sha256:7b356449cc952e6c0ecd2cd975b081362ab9ccf78ab2d305ffeb5949e3d0c538", size = 139802, upload-time = "2026-08-05T13:29:22.659Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/ae/f4786112f0e75d616218988484060218857e1abea81174162116e14597f5/polar_flow_api-1.4.0-py3-none-any.whl", hash = "sha256:7527a23096f0d4d1a9de0a6df5946913e4eee27f1563e9145f11226abbf63a8e", size = 42664, upload-time = "2026-01-11T12:02:47.944Z" },
+    { url = "https://files.pythonhosted.org/packages/39/d0/9811b77565809311bc609f0032a6d768cc4a0ba392c4e676b2dff3cea093/polar_flow_api-1.5.0-py3-none-any.whl", hash = "sha256:a6453f8dbc87e9491faa4bace882876104d9260d71fb20b6f656080e6e5d6ceb", size = 44971, upload-time = "2026-08-05T13:29:21.296Z" },
 ]
 
 [[package]]
@@ -1593,7 +1593,7 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=1.0.3" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.20.1" },
-    { name = "polar-flow-api", specifier = ">=1.4.0" },
+    { name = "polar-flow-api", specifier = ">=1.5.0" },
     { name = "polars", specifier = ">=1.17.1" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.3" },
     { name = "pyarrow", specifier = ">=23.0.1" },


### PR DESCRIPTION
Closes #75. **Stacked on #123** (migration chain). **Blocked on the polar-flow 1.5.0 release** ([polar-flow#16](https://github.com/StuMason/polar-flow/pull/16)) — `uv.lock` will be regenerated once it's on PyPI, until then CI fails on the frozen lock.

Polar shipped exactly what this issue wanted: a non-transactional `GET /v3/users/physical-info` (AccessLink changelog **13.01.2026**), deprecating the transaction dance. And since physical info is *profile* data, not watch-upload data, this endpoint returns real values today — lost watch or not.

## What it does
- **`physical_info` table** — snapshots keyed by `(user_id, recorded_at)` where `recorded_at` is Polar's `modified` timestamp: unchanged profiles upsert the same row (idempotent), real changes append — so weight and VO2 max build a history over time for free
- **Sync step** `_sync_physical_info` — single GET per sync, `hasattr`-gated (older SDKs skip cleanly), 404 = "never filled in" = quiet zero, not an error
- **REST**: `GET /users/{id}/physical-info` — latest snapshot + up to 10 older ones
- **MCP**: `get_baselines` now carries a `physical_info` block (VO2 max, max/resting HR, aerobic/anaerobic thresholds) — the reference values an assistant needs to interpret exercise heart rates and zones

Captured fields: weight, height, birthday, gender, max/resting HR, aerobic/anaerobic thresholds, VO2 max, weight source, training background, typical day, sleep goal (ISO duration → seconds).

321 tests passing (7 new), mypy clean against SDK 1.5.0.