### PR TITLE
Sync exercise detail: HR zones, samples, GPS routes (#76)

### DIFF
--- a/alembic/versions/k2l3m4n5o6p7_exercise_detail_columns.py
+++ b/alembic/versions/k2l3m4n5o6p7_exercise_detail_columns.py
@@ -1,0 +1,44 @@
+"""Add exercise detail columns: HR zones, samples, route (issue #76).
+
+Fetched inline via the samples/zones/route query flags on the modern
+hashed-ID exercise endpoint (SDK 1.5.0). Also captures running index
+and the Training Load Pro breakdown, which the API always returned.
+
+Revision ID: k2l3m4n5o6p7
+Revises: j1k2l3m4n5o6
+Create Date: 2026-08-05 14:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "k2l3m4n5o6p7"
+down_revision: str | None = "j1k2l3m4n5o6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add exercise detail columns."""
+    op.add_column("exercise", sa.Column("running_index", sa.Integer(), nullable=True))
+    op.add_column("exercise", sa.Column("training_load_pro_json", sa.Text(), nullable=True))
+    op.add_column("exercise", sa.Column("heart_rate_zones_json", sa.Text(), nullable=True))
+    op.add_column("exercise", sa.Column("samples_json", sa.Text(), nullable=True))
+    op.add_column("exercise", sa.Column("route_json", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop exercise detail columns."""
+    for col in (
+        "running_index",
+        "training_load_pro_json",
+        "heart_rate_zones_json",
+        "samples_json",
+        "route_json",
+    ):
+        op.drop_column("exercise", col)

--- a/src/polar_flow_server/api/data.py
+++ b/src/polar_flow_server/api/data.py
@@ -1,5 +1,6 @@
 """Comprehensive data API endpoints for all Polar data types."""
 
+import json
 from datetime import date, timedelta
 from typing import Annotated, Any
 
@@ -346,6 +347,79 @@ async def get_exercise_detail(
         "ascent_meters": r.ascent_meters,
         "descent_meters": r.descent_meters,
         "notes": r.notes,
+        "running_index": r.running_index,
+        "training_load_pro": (
+            json.loads(r.training_load_pro_json) if r.training_load_pro_json else None
+        ),
+        "heart_rate_zones": (
+            json.loads(r.heart_rate_zones_json) if r.heart_rate_zones_json else None
+        ),
+        "has_samples": r.samples_json is not None,
+        "has_route_data": r.route_json is not None,
+    }
+
+
+@get("/users/{user_id:str}/exercises/{exercise_id:str}/samples", status_code=HTTP_200_OK)
+async def get_exercise_samples(
+    user_id: str,
+    exercise_id: str,
+    session: AsyncSession,
+) -> dict[str, Any]:
+    """Get an exercise's raw sample series (HR, speed, cadence, altitude, ...).
+
+    Each series has a sample_type, recording_rate (seconds between samples),
+    and the values list.
+    """
+    stmt = select(Exercise).where(
+        Exercise.user_id == user_id,
+        Exercise.id == exercise_id,
+    )
+    result = await session.execute(stmt)
+    r = result.scalar_one_or_none()
+
+    if not r:
+        raise NotFoundException(detail=f"Exercise {exercise_id} not found")
+    if not r.samples_json:
+        raise NotFoundException(detail=f"Exercise {exercise_id} has no sample data")
+
+    return {
+        "exercise_id": r.id,
+        "sport": r.sport,
+        "start_time": str(r.start_time),
+        "samples": json.loads(r.samples_json),
+    }
+
+
+@get("/users/{user_id:str}/exercises/{exercise_id:str}/route", status_code=HTTP_200_OK)
+async def get_exercise_route(
+    user_id: str,
+    exercise_id: str,
+    session: AsyncSession,
+) -> dict[str, Any]:
+    """Get an exercise's GPS route as structured points.
+
+    Each point has latitude, longitude, time offset from exercise start
+    (ISO 8601 duration), satellites, and fix quality.
+    """
+    stmt = select(Exercise).where(
+        Exercise.user_id == user_id,
+        Exercise.id == exercise_id,
+    )
+    result = await session.execute(stmt)
+    r = result.scalar_one_or_none()
+
+    if not r:
+        raise NotFoundException(detail=f"Exercise {exercise_id} not found")
+    if not r.route_json:
+        raise NotFoundException(detail=f"Exercise {exercise_id} has no route data")
+
+    points = json.loads(r.route_json)
+    return {
+        "exercise_id": r.id,
+        "sport": r.sport,
+        "start_time": str(r.start_time),
+        "point_count": len(points),
+        "route": points,
     }
 
 
@@ -660,6 +734,8 @@ data_router = Router(
         # Exercises
         get_exercises_list,
         get_exercise_detail,
+        get_exercise_samples,
+        get_exercise_route,
         # SleepWise
         get_alertness_list,
         get_bedtime_list,

--- a/src/polar_flow_server/mcp_server/tools.py
+++ b/src/polar_flow_server/mcp_server/tools.py
@@ -11,6 +11,7 @@ prompt caches warm.
 """
 
 import asyncio
+import json
 from datetime import date, timedelta
 from typing import Annotated, Any, Literal
 
@@ -259,8 +260,12 @@ async def get_exercises(
     start time, duration (minutes), distance (km), calories, average/max
     heart rate (bpm), and training load. With `exercise_id`: every recorded
     metric for that single workout, including speed (m/s), cadence, power
-    (watts), and elevation. Training load is Polar's cardio strain estimate
-    for the session - compare against get_recovery's tolerance. Calories are
+    (watts), elevation, the time-in-zone heart rate breakdown (compare zone
+    limits against get_baselines physical_info thresholds), running index,
+    and Training Load Pro. `has_samples`/`route_point_count` say whether
+    raw per-second series and a GPS route exist (served by the REST API,
+    not this tool). Training load is Polar's cardio strain estimate for
+    the session - compare against get_recovery's tolerance. Calories are
     null when the device reported an implausibly low value for the duration
     (sensor noise, e.g. no HR strap) - null means unmeasured, not zero burn.
     """
@@ -296,6 +301,15 @@ async def get_exercises(
             "ascent_meters": r.ascent_meters,
             "descent_meters": r.descent_meters,
             "notes": r.notes,
+            "running_index": r.running_index,
+            "training_load_pro": (
+                json.loads(r.training_load_pro_json) if r.training_load_pro_json else None
+            ),
+            "heart_rate_zones": (
+                json.loads(r.heart_rate_zones_json) if r.heart_rate_zones_json else None
+            ),
+            "has_samples": r.samples_json is not None,
+            "route_point_count": (len(json.loads(r.route_json)) if r.route_json else 0),
         }
 
     since = date.today() - timedelta(days=days)

--- a/src/polar_flow_server/models/exercise.py
+++ b/src/polar_flow_server/models/exercise.py
@@ -81,6 +81,25 @@ class Exercise(Base, UserScopedMixin, TimestampMixin):
     # Has GPS data flag
     has_route: Mapped[bool] = mapped_column(default=False)
 
+    # Performance metrics
+    running_index: Mapped[int | None] = mapped_column(
+        Integer, comment="Polar running performance index"
+    )
+    training_load_pro_json: Mapped[str | None] = mapped_column(
+        Text, comment="JSON Training Load Pro breakdown (cardio/muscle/perceived)"
+    )
+
+    # Per-exercise detail stored as JSON (fetched via samples/zones/route flags)
+    heart_rate_zones_json: Mapped[str | None] = mapped_column(
+        Text, comment="JSON list of HR zones: index, lower/upper limit bpm, in-zone seconds"
+    )
+    samples_json: Mapped[str | None] = mapped_column(
+        Text, comment="JSON list of sample series: sample_type, recording_rate, values"
+    )
+    route_json: Mapped[str | None] = mapped_column(
+        Text, comment="JSON list of GPS points: latitude, longitude, time, satellites, fix"
+    )
+
     def __repr__(self) -> str:
         """String representation."""
         return (

--- a/src/polar_flow_server/services/sync.py
+++ b/src/polar_flow_server/services/sync.py
@@ -595,10 +595,19 @@ class SyncService:
         # Fetch from Polar API (last 30 days)
         exercises = await client.exercises.list()
 
+        # SDK >= 1.5.0 returns samples, HR zones and the GPS route inline
+        # via query flags on the detail call (get_route is new in 1.5.0)
+        supports_detail_flags = hasattr(client.exercises, "get_route")
+
         count = 0
         for exercise in exercises:
             # Get detailed exercise data
-            detailed = await client.exercises.get(exercise_id=exercise.id)
+            if supports_detail_flags:
+                detailed = await client.exercises.get(
+                    exercise_id=exercise.id, samples=True, zones=True, route=True
+                )
+            else:
+                detailed = await client.exercises.get(exercise_id=exercise.id)
 
             # Use transformer for type-safe SDK -> DB mapping
             exercise_dict = ExerciseTransformer.transform(detailed, user_id)

--- a/src/polar_flow_server/transformers/exercise.py
+++ b/src/polar_flow_server/transformers/exercise.py
@@ -5,6 +5,7 @@ Converts polar-flow SDK Exercise model to database-ready dictionary.
 
 from __future__ import annotations
 
+import json
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -46,6 +47,10 @@ class ExerciseTransformer:
         # Calculate stop_time from start_time + duration
         stop_time = sdk_exercise.start_time + timedelta(seconds=sdk_exercise.duration_seconds)
 
+        zones = getattr(sdk_exercise, "heart_rate_zones", None)
+        samples = getattr(sdk_exercise, "samples", None)
+        route = getattr(sdk_exercise, "route", None)
+
         return {
             "polar_exercise_id": sdk_exercise.id,
             "start_time": sdk_exercise.start_time,
@@ -60,4 +65,55 @@ class ExerciseTransformer:
             "calories": sdk_exercise.calories,
             "training_load": sdk_exercise.training_load,
             "has_route": sdk_exercise.has_route,
+            "running_index": getattr(sdk_exercise, "running_index", None),
+            "training_load_pro_json": (
+                json.dumps(sdk_exercise.training_load_pro)
+                if sdk_exercise.training_load_pro
+                else None
+            ),
+            "heart_rate_zones_json": (
+                json.dumps(
+                    [
+                        {
+                            "index": z.index,
+                            "lower_limit_bpm": z.lower_limit,
+                            "upper_limit_bpm": z.upper_limit,
+                            "in_zone_seconds": z.in_zone_seconds,
+                        }
+                        for z in zones
+                    ]
+                )
+                if zones
+                else None
+            ),
+            "samples_json": (
+                json.dumps(
+                    [
+                        {
+                            "sample_type": s.sample_type,
+                            "recording_rate": s.recording_rate,
+                            "values": s.values,
+                        }
+                        for s in samples
+                    ]
+                )
+                if samples
+                else None
+            ),
+            "route_json": (
+                json.dumps(
+                    [
+                        {
+                            "latitude": p.latitude,
+                            "longitude": p.longitude,
+                            "time": p.time,
+                            "satellites": p.satellites,
+                            "fix": p.fix,
+                        }
+                        for p in route
+                    ]
+                )
+                if route
+                else None
+            ),
         }

--- a/tests/test_exercise_detail.py
+++ b/tests/test_exercise_detail.py
@@ -1,0 +1,246 @@
+"""Tests for exercise detail capture: HR zones, samples, route (issue #76)."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+
+import pytest
+from polar_flow.models.exercise import Exercise as SDKExercise
+
+from polar_flow_server.transformers.exercise import ExerciseTransformer
+
+USER_ID = "polar-1"
+
+
+def _sdk_exercise(**overrides: object) -> SDKExercise:
+    base: dict[str, object] = {
+        "id": "2AC312F",
+        "upload-time": "2026-06-01T10:40:02.000Z",
+        "polar-user": "https://www.polaraccesslink.com/v3/users/1",
+        "device": "Polar Vantage V2",
+        "start-time": "2026-06-01T08:00:00Z",
+        "start-time-utc-offset": 60,
+        "duration": "PT1H",
+        "calories": 500,
+        "distance": 10000.0,
+        "heart-rate": {"average": 140, "maximum": 175},
+        "training-load": 80.0,
+        "sport": "RUNNING",
+        "has-route": True,
+        "running-index": 51,
+        "training-load-pro": {"cardio-load": 1.0, "muscle-load": "NOT_AVAILABLE"},
+        "heart_rate_zones": [
+            {"index": 1, "lower-limit": 100, "upper-limit": 120, "in-zone": "PT5M"},
+            {"index": 2, "lower-limit": 120, "upper-limit": 140, "in-zone": "PT30M"},
+        ],
+        "samples": [
+            {"sample-type": "0", "recording-rate": 5, "data": "120,125,130"},
+        ],
+        "route": [
+            {"latitude": 60.2198, "longitude": 25.1392, "time": "PT0S", "satellites": 4, "fix": 1},
+            {"latitude": 60.2199, "longitude": 25.1394, "time": "PT5S", "satellites": 5, "fix": 1},
+        ],
+    }
+    base.update(overrides)
+    return SDKExercise.model_validate(base)
+
+
+class TestExerciseTransformerDetail:
+    def test_captures_zones_samples_route(self) -> None:
+        result = ExerciseTransformer.transform(_sdk_exercise(), USER_ID)
+
+        zones = json.loads(result["heart_rate_zones_json"])
+        assert zones[0] == {
+            "index": 1,
+            "lower_limit_bpm": 100,
+            "upper_limit_bpm": 120,
+            "in_zone_seconds": 300,
+        }
+        assert zones[1]["in_zone_seconds"] == 1800
+
+        samples = json.loads(result["samples_json"])
+        assert samples[0]["sample_type"] == "0"
+        assert samples[0]["recording_rate"] == 5
+        assert samples[0]["values"] == [120.0, 125.0, 130.0]
+
+        route = json.loads(result["route_json"])
+        assert len(route) == 2
+        assert route[0]["latitude"] == 60.2198
+        assert route[1]["satellites"] == 5
+
+    def test_captures_running_index_and_tlp(self) -> None:
+        result = ExerciseTransformer.transform(_sdk_exercise(), USER_ID)
+
+        assert result["running_index"] == 51
+        tlp = json.loads(result["training_load_pro_json"])
+        assert tlp["cardio-load"] == 1.0
+
+    def test_without_detail_stays_null(self) -> None:
+        result = ExerciseTransformer.transform(
+            _sdk_exercise(
+                heart_rate_zones=None,
+                samples=None,
+                route=None,
+                **{"running-index": None, "training-load-pro": None},
+            ),
+            USER_ID,
+        )
+
+        assert result["heart_rate_zones_json"] is None
+        assert result["samples_json"] is None
+        assert result["route_json"] is None
+        assert result["running_index"] is None
+        assert result["training_load_pro_json"] is None
+
+    def test_existing_fields_unchanged(self) -> None:
+        result = ExerciseTransformer.transform(_sdk_exercise(), USER_ID)
+
+        assert result["polar_exercise_id"] == "2AC312F"
+        assert result["sport"] == "RUNNING"
+        assert result["calories"] == 500
+        assert result["average_heart_rate"] == 140
+        assert result["has_route"] is True
+
+
+async def _seed_user_with_key() -> str:
+    from polar_flow_server.core.api_keys import create_api_key_for_user
+    from polar_flow_server.core.database import async_session_maker
+    from polar_flow_server.models.user import User
+
+    async with async_session_maker() as session:
+        session.add(
+            User(
+                id="user-1",
+                polar_user_id=USER_ID,
+                access_token_encrypted="not-a-real-token",
+                is_active=True,
+            )
+        )
+        await session.flush()
+        _, raw_key = await create_api_key_for_user(
+            user_id=USER_ID, name="test key", session=session
+        )
+        await session.commit()
+    return raw_key
+
+
+async def _seed_exercise(*, with_detail: bool) -> None:
+    from polar_flow_server.core.database import async_session_maker
+    from polar_flow_server.models.exercise import Exercise
+
+    async with async_session_maker() as session:
+        session.add(
+            Exercise(
+                id="exercise-1",
+                user_id=USER_ID,
+                polar_exercise_id="2AC312F",
+                start_time=dt.datetime(2026, 6, 1, 8, 0, tzinfo=dt.UTC),
+                sport="RUNNING",
+                duration_seconds=3600,
+                running_index=51 if with_detail else None,
+                heart_rate_zones_json=(
+                    json.dumps(
+                        [
+                            {
+                                "index": 1,
+                                "lower_limit_bpm": 100,
+                                "upper_limit_bpm": 120,
+                                "in_zone_seconds": 300,
+                            }
+                        ]
+                    )
+                    if with_detail
+                    else None
+                ),
+                samples_json=(
+                    json.dumps(
+                        [{"sample_type": "0", "recording_rate": 5, "values": [120, 125, 130]}]
+                    )
+                    if with_detail
+                    else None
+                ),
+                route_json=(
+                    json.dumps([{"latitude": 60.2198, "longitude": 25.1392, "time": "PT0S"}])
+                    if with_detail
+                    else None
+                ),
+            )
+        )
+        await session.commit()
+
+
+class TestExerciseDetailEndpoints:
+    @pytest.mark.asyncio
+    async def test_detail_carries_zones_and_flags(self, app_client) -> None:
+        key = await _seed_user_with_key()
+        await _seed_exercise(with_detail=True)
+
+        response = await app_client.get(
+            f"/api/v1/users/{USER_ID}/exercises/exercise-1", headers={"X-API-Key": key}
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["running_index"] == 51
+        assert payload["heart_rate_zones"][0]["in_zone_seconds"] == 300
+        assert payload["has_samples"] is True
+        assert payload["has_route_data"] is True
+
+    @pytest.mark.asyncio
+    async def test_samples_endpoint(self, app_client) -> None:
+        key = await _seed_user_with_key()
+        await _seed_exercise(with_detail=True)
+
+        response = await app_client.get(
+            f"/api/v1/users/{USER_ID}/exercises/exercise-1/samples", headers={"X-API-Key": key}
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["samples"][0]["values"] == [120, 125, 130]
+
+    @pytest.mark.asyncio
+    async def test_route_endpoint(self, app_client) -> None:
+        key = await _seed_user_with_key()
+        await _seed_exercise(with_detail=True)
+
+        response = await app_client.get(
+            f"/api/v1/users/{USER_ID}/exercises/exercise-1/route", headers={"X-API-Key": key}
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["point_count"] == 1
+        assert payload["route"][0]["latitude"] == 60.2198
+
+    @pytest.mark.asyncio
+    async def test_missing_detail_is_404(self, app_client) -> None:
+        key = await _seed_user_with_key()
+        await _seed_exercise(with_detail=False)
+
+        for sub in ("samples", "route"):
+            response = await app_client.get(
+                f"/api/v1/users/{USER_ID}/exercises/exercise-1/{sub}",
+                headers={"X-API-Key": key},
+            )
+            assert response.status_code == 404
+            assert "has no" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_mcp_detail_carries_zones(self, app_client) -> None:
+        from tests.test_mcp_server import _mcp_client, _seed_user, _user_key
+
+        user_id = await _seed_user(USER_ID)
+        await _seed_exercise(with_detail=True)
+        raw_key = await _user_key(user_id)
+
+        async with _mcp_client(app_client.app, raw_key) as client:
+            result = await client.call_tool("get_exercises", {"exercise_id": "exercise-1"})
+
+        assert not result.is_error
+        payload = result.structured_content
+        assert payload["running_index"] == 51
+        assert payload["heart_rate_zones"][0]["index"] == 1
+        assert payload["has_samples"] is True
+        assert payload["route_point_count"] == 1


### PR DESCRIPTION
Closes #76. **Stacked on #125** (which stacks on #123). Same release gate: needs polar-flow-api **1.5.0** on PyPI, then a lock regen turns the train green.

The API recon changed this issue's shape for the better: the modern hashed-ID endpoint returns samples, zones **and the route as structured JSON** in one call (`GET /v3/exercises/{id}?samples=true&zones=true&route=true`) — no extra requests, no GPX parsing. (The SDK's old `get_samples()`/`get_zones()` sub-path calls were latently 404-broken; fixed in polar-flow#16.)

## What it does
- **Sync**: the per-exercise detail call now passes all three flags (`hasattr`-gated on the SDK's `get_route`, so older SDKs keep the plain call). Stored as JSON: `heart_rate_zones_json` (index, limits, in-zone seconds), `samples_json` (type, recording rate, values), `route_json` (lat/lon/time/satellites/fix). Plus two fields the API always returned and we dropped: `running_index` and `training_load_pro_json`.
- **REST**: exercise detail gains zones + running index + Training Load Pro inline, with `has_samples`/`has_route_data` flags; new `GET .../exercises/{id}/samples` and `GET .../exercises/{id}/route` serve the heavy series (404 with a clear message when absent).
- **MCP**: `get_exercises` detail gains the time-in-zone breakdown (the docstring points agents at `get_baselines.physical_info` thresholds to interpret it), `running_index`, `training_load_pro`, and availability flags — raw per-second series stay out of agent context by design.

Like #77, this is capture-before-the-watch-returns work: exercises older than 30 days can never be re-fetched, so the flags being on *before* the next upload is what makes the detail permanent.

330 tests passing (9 new), mypy clean against SDK 1.5.0. Migration `k2l3m4n5o6p7`.