### PR TITLE
Expose minute-level samples through the REST API (#67)

### DIFF
--- a/src/polar_flow_server/api/data.py
+++ b/src/polar_flow_server/api/data.py
@@ -260,6 +260,45 @@ async def get_heart_rate_list(
     ]
 
 
+@get("/users/{user_id:str}/heart-rate/{target_date:str}/samples", status_code=HTTP_200_OK)
+async def get_heart_rate_samples(
+    user_id: str,
+    target_date: Annotated[
+        str,
+        Parameter(
+            description="Date to retrieve heart rate samples for (YYYY-MM-DD format)",
+            pattern=r"^\d{4}-\d{2}-\d{2}$",
+        ),
+    ],
+    session: AsyncSession,
+) -> dict[str, Any]:
+    """Get a day's continuous heart rate samples (~5-minute intervals).
+
+    Each sample has a timestamp and a bpm value; zero/no-signal samples
+    were excluded at sync time.
+    """
+    stmt = select(ContinuousHeartRate).where(
+        ContinuousHeartRate.user_id == user_id,
+        ContinuousHeartRate.date == date.fromisoformat(target_date),
+    )
+    result = await session.execute(stmt)
+    r = result.scalar_one_or_none()
+
+    if not r:
+        raise NotFoundException(detail=f"No heart rate data for {target_date}")
+    if not r.samples_json:
+        raise NotFoundException(detail=f"Heart rate data for {target_date} has no samples")
+
+    return {
+        "date": str(r.date),
+        "hr_min": r.hr_min,
+        "hr_avg": r.hr_avg,
+        "hr_max": r.hr_max,
+        "sample_count": r.sample_count,
+        "samples": json.loads(r.samples_json),
+    }
+
+
 # ==============================================================================
 # Exercise Endpoints
 # ==============================================================================
@@ -520,6 +559,44 @@ async def get_activity_samples_list(
     ]
 
 
+@get("/users/{user_id:str}/activity-samples/{target_date:str}", status_code=HTTP_200_OK)
+async def get_activity_samples_by_date(
+    user_id: str,
+    target_date: Annotated[
+        str,
+        Parameter(
+            description="Date to retrieve activity samples for (YYYY-MM-DD format)",
+            pattern=r"^\d{4}-\d{2}-\d{2}$",
+        ),
+    ],
+    session: AsyncSession,
+) -> dict[str, Any]:
+    """Get a day's minute-by-minute step samples.
+
+    `interval_ms` is the spacing between samples (60000 = 1 minute); each
+    sample carries a timestamp and the steps recorded in that interval.
+    """
+    stmt = select(ActivitySamples).where(
+        ActivitySamples.user_id == user_id,
+        ActivitySamples.date == date.fromisoformat(target_date),
+    )
+    result = await session.execute(stmt)
+    r = result.scalar_one_or_none()
+
+    if not r:
+        raise NotFoundException(detail=f"No activity samples for {target_date}")
+    if not r.samples_json:
+        raise NotFoundException(detail=f"Activity data for {target_date} has no samples")
+
+    return {
+        "date": str(r.date),
+        "total_steps": r.total_steps,
+        "interval_ms": r.interval_ms,
+        "sample_count": r.sample_count,
+        "samples": json.loads(r.samples_json),
+    }
+
+
 # ==============================================================================
 # Biosensing Endpoints (SpO2, ECG, Temperature)
 # ==============================================================================
@@ -574,6 +651,7 @@ async def get_ecg_list(
 
     return [
         {
+            "id": r.id,
             "test_time": str(r.test_time),
             "avg_heart_rate": r.avg_heart_rate,
             "hrv_ms": r.hrv_ms,
@@ -581,9 +659,49 @@ async def get_ecg_list(
             "rri_ms": r.rri_ms,
             "duration_seconds": r.duration_seconds,
             "sample_count": r.sample_count,
+            "has_samples": r.samples_json is not None,
         }
         for r in records
     ]
+
+
+@get("/users/{user_id:str}/ecg/{ecg_id:int}", status_code=HTTP_200_OK)
+async def get_ecg_detail(
+    user_id: str,
+    ecg_id: int,
+    session: AsyncSession,
+) -> dict[str, Any]:
+    """Get one ECG test's full detail including the waveform samples.
+
+    `samples` is the raw ECG waveform; `quality` carries the per-segment
+    quality measurements when the device recorded them.
+    """
+    stmt = select(ECG).where(
+        ECG.user_id == user_id,
+        ECG.id == ecg_id,
+    )
+    result = await session.execute(stmt)
+    r = result.scalar_one_or_none()
+
+    if not r:
+        raise NotFoundException(detail=f"ECG test {ecg_id} not found")
+
+    return {
+        "id": r.id,
+        "test_time": str(r.test_time),
+        "device_id": r.device_id,
+        "avg_heart_rate": r.avg_heart_rate,
+        "hrv_ms": r.hrv_ms,
+        "hrv_level": r.hrv_level,
+        "rri_ms": r.rri_ms,
+        "ptt_systolic_ms": r.ptt_systolic_ms,
+        "ptt_diastolic_ms": r.ptt_diastolic_ms,
+        "ptt_quality_index": r.ptt_quality_index,
+        "duration_seconds": r.duration_seconds,
+        "sample_count": r.sample_count,
+        "samples": json.loads(r.samples_json) if r.samples_json else None,
+        "quality": json.loads(r.quality_json) if r.quality_json else None,
+    }
 
 
 @get("/users/{user_id:str}/temperature/body", status_code=HTTP_200_OK)
@@ -731,6 +849,7 @@ data_router = Router(
         get_cardio_load_list,
         # Heart Rate
         get_heart_rate_list,
+        get_heart_rate_samples,
         # Exercises
         get_exercises_list,
         get_exercise_detail,
@@ -741,9 +860,11 @@ data_router = Router(
         get_bedtime_list,
         # Activity Samples
         get_activity_samples_list,
+        get_activity_samples_by_date,
         # Biosensing
         get_spo2_list,
         get_ecg_list,
+        get_ecg_detail,
         get_body_temperature_list,
         get_skin_temperature_list,
         # Export

--- a/src/polar_flow_server/api/data.py
+++ b/src/polar_flow_server/api/data.py
@@ -274,8 +274,8 @@ async def get_heart_rate_samples(
 ) -> dict[str, Any]:
     """Get a day's continuous heart rate samples (~5-minute intervals).
 
-    Each sample has a timestamp and a bpm value; zero/no-signal samples
-    were excluded at sync time.
+    Each sample carries a `sample_time` and a `heart_rate` in bpm;
+    zero/no-signal samples were excluded at sync time.
     """
     stmt = select(ContinuousHeartRate).where(
         ContinuousHeartRate.user_id == user_id,

--- a/tests/test_samples_api.py
+++ b/tests/test_samples_api.py
@@ -1,0 +1,212 @@
+"""Tests for minute-level sample endpoints (issue #67).
+
+Stored `samples_json` was synced but unreachable: clients only ever saw
+`has_samples` flags and daily aggregates. These endpoints serve the
+actual intraday data.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+
+import pytest
+
+USER_ID = "polar-1"
+TARGET_DATE = dt.date(2026, 6, 1)
+
+
+async def _seed_user_with_key() -> str:
+    from polar_flow_server.core.api_keys import create_api_key_for_user
+    from polar_flow_server.core.database import async_session_maker
+    from polar_flow_server.models.user import User
+
+    async with async_session_maker() as session:
+        session.add(
+            User(
+                id="user-1",
+                polar_user_id=USER_ID,
+                access_token_encrypted="not-a-real-token",
+                is_active=True,
+            )
+        )
+        await session.flush()
+        _, raw_key = await create_api_key_for_user(
+            user_id=USER_ID, name="test key", session=session
+        )
+        await session.commit()
+    return raw_key
+
+
+async def _seed_sample_data(*, with_samples: bool = True) -> int:
+    """Seed one day of activity samples + continuous HR + one ECG; return ECG id."""
+    from polar_flow_server.core.database import async_session_maker
+    from polar_flow_server.models.activity_samples import ActivitySamples
+    from polar_flow_server.models.continuous_hr import ContinuousHeartRate
+    from polar_flow_server.models.ecg import ECG
+
+    async with async_session_maker() as session:
+        session.add(
+            ActivitySamples(
+                user_id=USER_ID,
+                date=TARGET_DATE,
+                total_steps=8000,
+                interval_ms=60000,
+                sample_count=3,
+                samples_json=(
+                    json.dumps(
+                        [
+                            {"time": "08:00:00", "steps": 12},
+                            {"time": "08:01:00", "steps": 40},
+                            {"time": "08:02:00", "steps": 0},
+                        ]
+                    )
+                    if with_samples
+                    else None
+                ),
+            )
+        )
+        session.add(
+            ContinuousHeartRate(
+                user_id=USER_ID,
+                date=TARGET_DATE,
+                sample_count=2,
+                hr_min=52,
+                hr_avg=64,
+                hr_max=110,
+                samples_json=(
+                    json.dumps(
+                        [
+                            {"time": "08:00:00", "heart_rate": 62},
+                            {"time": "08:05:00", "heart_rate": 66},
+                        ]
+                    )
+                    if with_samples
+                    else None
+                ),
+            )
+        )
+        ecg = ECG(
+            user_id=USER_ID,
+            device_id="ABC123",
+            test_time=dt.datetime(2026, 6, 1, 8, 30, tzinfo=dt.UTC),
+            avg_heart_rate=61,
+            hrv_ms=42.0,
+            hrv_level="NORMAL",
+            rri_ms=980.0,
+            sample_count=3,
+            duration_seconds=30.0,
+            samples_json=json.dumps([0.12, 0.14, 0.11]) if with_samples else None,
+            quality_json=json.dumps([{"segment": 1, "quality": "GOOD"}]) if with_samples else None,
+        )
+        session.add(ecg)
+        await session.commit()
+        return ecg.id
+
+
+class TestActivitySamplesByDate:
+    @pytest.mark.asyncio
+    async def test_returns_parsed_samples(self, app_client) -> None:
+        key = await _seed_user_with_key()
+        await _seed_sample_data()
+
+        response = await app_client.get(
+            f"/api/v1/users/{USER_ID}/activity-samples/{TARGET_DATE}", headers={"X-API-Key": key}
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["total_steps"] == 8000
+        assert payload["interval_ms"] == 60000
+        assert payload["samples"][1] == {"time": "08:01:00", "steps": 40}
+
+    @pytest.mark.asyncio
+    async def test_missing_date_404(self, app_client) -> None:
+        key = await _seed_user_with_key()
+
+        response = await app_client.get(
+            f"/api/v1/users/{USER_ID}/activity-samples/2020-01-01", headers={"X-API-Key": key}
+        )
+
+        assert response.status_code == 404
+        assert "No activity samples" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_record_without_samples_404(self, app_client) -> None:
+        key = await _seed_user_with_key()
+        await _seed_sample_data(with_samples=False)
+
+        response = await app_client.get(
+            f"/api/v1/users/{USER_ID}/activity-samples/{TARGET_DATE}", headers={"X-API-Key": key}
+        )
+
+        assert response.status_code == 404
+        assert "has no samples" in response.json()["detail"]
+
+
+class TestHeartRateSamples:
+    @pytest.mark.asyncio
+    async def test_returns_parsed_samples(self, app_client) -> None:
+        key = await _seed_user_with_key()
+        await _seed_sample_data()
+
+        response = await app_client.get(
+            f"/api/v1/users/{USER_ID}/heart-rate/{TARGET_DATE}/samples",
+            headers={"X-API-Key": key},
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["hr_min"] == 52
+        assert payload["samples"][0]["heart_rate"] == 62
+
+    @pytest.mark.asyncio
+    async def test_missing_date_404(self, app_client) -> None:
+        key = await _seed_user_with_key()
+
+        response = await app_client.get(
+            f"/api/v1/users/{USER_ID}/heart-rate/2020-01-01/samples", headers={"X-API-Key": key}
+        )
+
+        assert response.status_code == 404
+
+
+class TestECGDetail:
+    @pytest.mark.asyncio
+    async def test_returns_waveform(self, app_client) -> None:
+        key = await _seed_user_with_key()
+        ecg_id = await _seed_sample_data()
+
+        response = await app_client.get(
+            f"/api/v1/users/{USER_ID}/ecg/{ecg_id}", headers={"X-API-Key": key}
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["samples"] == [0.12, 0.14, 0.11]
+        assert payload["quality"][0]["quality"] == "GOOD"
+        assert payload["hrv_ms"] == 42.0
+
+    @pytest.mark.asyncio
+    async def test_list_carries_id_and_flag(self, app_client) -> None:
+        key = await _seed_user_with_key()
+        ecg_id = await _seed_sample_data()
+
+        response = await app_client.get(
+            f"/api/v1/users/{USER_ID}/ecg?days=365", headers={"X-API-Key": key}
+        )
+
+        assert response.status_code == 200
+        record = response.json()[0]
+        assert record["id"] == ecg_id
+        assert record["has_samples"] is True
+
+    @pytest.mark.asyncio
+    async def test_missing_ecg_404(self, app_client) -> None:
+        key = await _seed_user_with_key()
+
+        response = await app_client.get(
+            f"/api/v1/users/{USER_ID}/ecg/999999", headers={"X-API-Key": key}
+        )
+
+        assert response.status_code == 404


### PR DESCRIPTION
Closes #67.

`ActivitySamples.samples_json`, `ContinuousHeartRate.samples_json` and `ECG.samples_json` were all synced and stored — and completely unreachable. The API only ever admitted `has_samples: true`. This serves the actual data:

- **`GET /users/{id}/activity-samples/{date}`** — minute-by-minute step samples with `interval_ms` and summary
- **`GET /users/{id}/heart-rate/{date}/samples`** — the ~5-minute continuous HR series (zero/no-signal samples were already excluded at sync)
- **`GET /users/{id}/ecg/{ecg_id}`** — one test's full detail: waveform samples, per-segment quality, PTT values. The ECG list now carries `id` + `has_samples` so the detail is addressable (it previously had no identifier at all)

Same shape and 404 discipline as the `/exercises/{id}/samples` + `/route` endpoints from #126. All work on already-stored history — verifiable on real data today.

338 tests passing (8 new), mypy clean.