### PR TITLE
Publish to the official MCP Registry + cut v1.5.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,3 +46,58 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  mcp-registry:
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    permissions:
+      id-token: write # OIDC auth to the MCP registry
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Get version from pyproject.toml
+        id: version
+        run: |
+          VERSION=$(grep -m1 'version = ' pyproject.toml | cut -d'"' -f2)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Skip if this version is already in the registry
+        id: check
+        run: |
+          LATEST=$(curl -s "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.StuMason/polar-flow-server" \
+            | jq -r '.servers[] | select(.server.name == "io.github.StuMason/polar-flow-server") | .server.version' | head -1)
+          echo "Registry has: ${LATEST:-nothing}; building: ${{ steps.version.outputs.version }}"
+          if [ "$LATEST" = "${{ steps.version.outputs.version }}" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install mcp-publisher
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+
+      - name: Set version in server.json
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          jq --arg v "$VERSION" \
+            '.version = $v | .packages[0].identifier = "docker.io/stumason/polar-flow-server:" + $v' \
+            server.json > server.tmp && mv server.tmp server.json
+
+      - name: Authenticate to MCP Registry
+        if: steps.check.outputs.skip != 'true'
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          # Docker Hub propagation can lag right after push — retry a few times
+          for i in 1 2 3; do
+            ./mcp-publisher publish && exit 0
+            echo "Registry publish attempt $i failed; retrying in 30s..."
+            sleep 30
+          done
+          exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,8 +67,9 @@ jobs:
       - name: Skip if this version is already in the registry
         id: check
         run: |
-          LATEST=$(curl -s "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.StuMason/polar-flow-server" \
-            | jq -r '.servers[] | select(.server.name == "io.github.StuMason/polar-flow-server") | .server.version' | head -1)
+          # A lookup hiccup must not kill the release — treat as "not yet published"
+          LATEST=$(curl -s --max-time 30 "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.StuMason/polar-flow-server" \
+            | jq -r '.servers[] | select(.server.name == "io.github.StuMason/polar-flow-server") | .server.version' | head -1 || true)
           echo "Registry has: ${LATEST:-nothing}; building: ${{ steps.version.outputs.version }}"
           if [ "$LATEST" = "${{ steps.version.outputs.version }}" ]; then
             echo "skip=true" >> $GITHUB_OUTPUT
@@ -77,7 +78,7 @@ jobs:
       - name: Install mcp-publisher
         if: steps.check.outputs.skip != 'true'
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.8.0/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
 
       - name: Set version in server.json
         if: steps.check.outputs.skip != 'true'
@@ -97,7 +98,7 @@ jobs:
           # Docker Hub propagation can lag right after push — retry a few times
           for i in 1 2 3; do
             ./mcp-publisher publish && exit 0
-            echo "Registry publish attempt $i failed; retrying in 30s..."
-            sleep 30
+            echo "Registry publish attempt $i failed"
+            [ "$i" -lt 3 ] && sleep 30
           done
           exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ECG waveform chart, body-temperature trend with min/max band, SleepWise alertness curve, circadian bedtime card
 
 **MCP Registry**
-- `server.json` + CI publishing to the official MCP Registry as `io.github.stumason/polar-flow-server`
+- `server.json` + CI publishing to the official MCP Registry as `io.github.StuMason/polar-flow-server`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-08-06
+
+### Added
+
+**Built-in MCP Server** (#80, #114, #116, #117)
+- Model Context Protocol server (protocol revision 2026-07-28, streamable HTTP) mounted at `/mcp`
+- Ten curated tools: health assessment, sleep, recovery, activity, exercises, seven biosensing streams, baselines, patterns/anomalies, and sync control
+- Per-user API-key auth for headless clients
+
+**OAuth 2.1 Sign-In for MCP Connectors** (#118, #119)
+- With `BASE_URL` set, the server is its own OAuth 2.1 authorization server: add `/mcp` as a custom connector in claude.ai / Claude Desktop and sign in — no key pasting
+- User-scoped, hourly-expiring, auto-refreshing tokens; connected apps revocable from Settings
+
+**MCP Apps Card** (#120, #121)
+- "Today at a glance" renders as an interactive card in clients that support MCP Apps
+
+**Deeper Polar Data Capture** (#75, #76, #77)
+- Physical info sync: VO2 max, aerobic/anaerobic thresholds, resting/max HR, weight, height, sleep goal (new `GET /v3/users/physical-info` endpoint, SDK 1.5.0)
+- Exercise detail: heart-rate zones, per-second samples, and GPS routes stored per workout
+- Previously dropped sleep/recharge fields captured: hypnogram, sleep HR samples, HRV and breathing samples, nightly recharge status
+
+**Minute-Level Samples API** (#67, #127)
+- `GET /users/{id}/activity-samples/{date}`, `GET /users/{id}/heart-rate/{date}/samples`, `GET /users/{id}/ecg/{id}` (full waveform + quality)
+
+**Dashboard: Stored Detail Rendered** (#74, #78)
+- Recent Workouts table with per-zone time bars on the Training tab
+- ECG waveform chart, body-temperature trend with min/max band, SleepWise alertness curve, circadian bedtime card
+
+**MCP Registry**
+- `server.json` + CI publishing to the official MCP Registry as `io.github.stumason/polar-flow-server`
+
+### Fixed
+
+- Security sprint (#50–#57): persistent encryption/session keys across redeploys, CSRF on destructive admin POSTs, proxy-aware login rate limiting, gated first-run setup, hardened headers/cookies/session rotation, registered SaaS OAuth callback origins, non-root container
+- Bug sprint (#58–#66): SpO2 tiles, real 401s and user-scoped queries in admin charts, propagated biosensing sync errors, concurrent-sync guard, reachable exercise detail (404s on missing data), live rate-limit tracking with transient-error retry
+- Chart-label day shift west of UTC; UTC-labelled timestamps throughout (#108, #109)
+- ANS load scale alignment (#49)
+
+### Changed
+
+- Frontend assets vendored — no CDN calls from production pages (#110)
+- Dashboard/settings page loads batched (~20 sequential queries collapsed) (#112)
+- Accessibility: tab ARIA + arrow keys, dropdown/modal semantics, chart alt text (#111)
+- Docs and README refreshed with current screenshots and MCP-first positioning (#113, #122)
+- polar-flow SDK dependency raised to 1.5.0
+
 ## [1.4.0] - 2026-07-19
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ ENV KEY_DIR=/data/keys
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
+# MCP Registry ownership verification (must match server.json name)
+LABEL io.modelcontextprotocol.server.name="io.github.StuMason/polar-flow-server"
+
 # Expose port
 EXPOSE 8000
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Polar API → polar-flow SDK → Sync Service → PostgreSQL
 - HTMX + Tailwind (admin UI)
 - polar-flow SDK v1.5.0
 
+> **Don't fancy running a server?** A hosted version is in the works — [join the waitlist](https://pulse.stumason.dev). Self-hosting stays free forever.
+
 ## Quick Start
 
 ### Option 1: Docker (Recommended)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Polar API → polar-flow SDK → Sync Service → PostgreSQL
 - SQLAlchemy 2.0 (async ORM)
 - PostgreSQL
 - HTMX + Tailwind (admin UI)
-- polar-flow SDK v1.3.0
+- polar-flow SDK v1.5.0
 
 ## Quick Start
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "polar-flow-server"
-version = "1.4.0"
+version = "1.5.0"
 description = "Self-hosted health analytics server for Polar devices"
 readme = "README.md"
 authors = [

--- a/server.json
+++ b/server.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.StuMason/polar-flow-server",
+  "title": "Polar Health Data (self-hosted)",
+  "description": "Self-hosted health analytics for Polar devices with a built-in MCP server: sleep, HRV, workouts, biosensing, and personal baselines your AI can read.",
+  "repository": {
+    "url": "https://github.com/StuMason/polar-flow-server",
+    "source": "github"
+  },
+  "version": "0.0.0",
+  "websiteUrl": "https://stumason.github.io/polar-flow-server/",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "docker.io/stumason/polar-flow-server:0.0.0",
+      "transport": {
+        "type": "streamable-http",
+        "url": "http://localhost:8000/mcp"
+      },
+      "environmentVariables": [
+        {
+          "name": "DATABASE_URL",
+          "description": "PostgreSQL connection string, e.g. postgresql+asyncpg://user:pass@host:5432/polar",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "POLAR_CLIENT_ID",
+          "description": "Polar AccessLink OAuth client id (register at admin.polaraccesslink.com)",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "POLAR_CLIENT_SECRET",
+          "description": "Polar AccessLink OAuth client secret",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "BASE_URL",
+          "description": "Public HTTPS base URL of this deployment; enables OAuth sign-in for MCP connectors",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Gets this server listed in the [official MCP Registry](https://registry.modelcontextprotocol.io) (which PulseMCP, Glama and friends crawl), and cuts **v1.5.0** so there's a labelled image version for the registry to verify.

- `server.json` — registry metadata as `io.github.StuMason/polar-flow-server`, OCI package pointing at `docker.io/stumason/polar-flow-server:<version>`, streamable-http transport, env-var docs
- `Dockerfile` — `io.modelcontextprotocol.server.name` label (how the registry verifies image ownership)
- `publish.yml` — new `mcp-registry` job chained after the Docker push: OIDC auth (no secrets), skips when the version is already published, retries around Docker Hub propagation lag. Mirrors the proven coolify-mcp setup.
- `pyproject.toml` → **1.5.0** + full CHANGELOG entry for the 35 commits since 1.4.0 (MCP server + OAuth, Apps card, security sprint, data depth, dashboard detail)
- README: stack section said SDK v1.3.0, now 1.5.0

## Notes

Registry publish is a no-op until this merges to main (version check makes it idempotent on every subsequent push).